### PR TITLE
Rename ukfast to ans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 /debug
 .vscode/
 *.test
-/ukfast.exe
-/ukfast
+/ans.exe
+/ans
 cover.out
 dist/
 __debug_bin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,11 +1,7 @@
-project_name: ukfast
-before:
-  hooks:
-    - go mod download
+project_name: ans
 builds:
 - env:
   - CGO_ENABLED=0
-  - GO111MODULE=on
   ldflags:
     - -s -X main.VERSION={{.Version}} -X main.BUILDDATE={{.Date}}
   goos:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ RUN apk --no-cache add git
 COPY . /build/
 WORKDIR /build
 ENV CGO_ENABLED 0
-RUN go build -o ukfast -ldflags "-s -X 'main.VERSION=$(git describe --tags)' -X 'main.BUILDDATE=$(date +'%Y-%m-%dT%H:%M:%S')'"
+RUN go build -o ans -ldflags "-s -X 'main.VERSION=$(git describe --tags)' -X 'main.BUILDDATE=$(date +'%Y-%m-%dT%H:%M:%S')'"
 
 FROM alpine:3.13
 RUN apk --no-cache add ca-certificates bash bash-completion
-COPY --from=builder /build/ukfast /bin/ukfast
+COPY --from=builder /build/ans /bin/ans
 RUN echo "source /usr/share/bash-completion/bash_completion" >> ~/.bashrc
-RUN echo "source <(ukfast completion bash)" >> ~/.bashrc
-ENTRYPOINT ["/bin/ukfast"]
+RUN echo "source <(ans completion bash)" >> ~/.bashrc
+ENTRYPOINT ["/bin/ans"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.16.4-alpine3.13 AS builder
+FROM golang:1.18-alpine3.16 AS builder
 RUN apk --no-cache add git
 COPY . /build/
 WORKDIR /build
 ENV CGO_ENABLED 0
 RUN go build -o ans -ldflags "-s -X 'main.VERSION=$(git describe --tags)' -X 'main.BUILDDATE=$(date +'%Y-%m-%dT%H:%M:%S')'"
 
-FROM alpine:3.13
+FROM alpine:3.16
 RUN apk --no-cache add ca-certificates bash bash-completion
 COPY --from=builder /build/ans /bin/ans
 RUN echo "source /usr/share/bash-completion/bash_completion" >> ~/.bashrc

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,20 @@
 .PHONY: build build_windows build_mac test
 
 build:
-	go build -o ukfast -ldflags "-s -X 'main.VERSION=$$(git describe --tags)' -X 'main.BUILDDATE=$$(date +'%Y-%m-%dT%H:%M:%S')'"
+	go build -o ans -ldflags "-s -X 'main.VERSION=$$(git describe --tags)' -X 'main.BUILDDATE=$$(date +'%Y-%m-%dT%H:%M:%S')'"
 
 clean:
 	go clean --modcache 
-	rm ukfast
+	rm ans
 
 install: 
-	sudo cp ukfast /usr/local/bin/    
+	sudo cp ans /usr/local/bin/    
 
 build_windows:
-	GOOS=windows go build -o ukfast.exe -ldflags "-s -X 'main.VERSION=$$(git describe --tags)' -X 'main.BUILDDATE=$$(date +'%Y-%m-%dT%H:%M:%S')'"
+	GOOS=windows go build -o ans.exe -ldflags "-s -X 'main.VERSION=$$(git describe --tags)' -X 'main.BUILDDATE=$$(date +'%Y-%m-%dT%H:%M:%S')'"
 
 build_mac:
-	GOOS=darwin go build -o ukfast -ldflags "-s -X 'main.VERSION=$$(git describe --tags)' -X 'main.BUILDDATE=$$(date +'%Y-%m-%dT%H:%M:%S')'"
+	GOOS=darwin go build -o ans -ldflags "-s -X 'main.VERSION=$$(git describe --tags)' -X 'main.BUILDDATE=$$(date +'%Y-%m-%dT%H:%M:%S')'"
 
 test:
 	go test -v -cover ./...

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# UKFast CLI
+# ANS CLI
 
-[![Build Status](https://travis-ci.org/ukfast/cli.svg?branch=master)](https://travis-ci.org/ukfast/cli)
+[![Build Status](https://travis-ci.org/ans/cli.svg?branch=master)](https://travis-ci.org/ans/cli)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-This is the official UKFast command-line client, allowing for querying and controlling
-supported UKFast services.
+This is the official ANS command-line client, allowing for querying and controlling
+supported ANS services.
 
-The client utilises UKFast APIs to provide access to most service features. You should refer to the 
+The client utilises ANS APIs to provide access to most service features. You should refer to the 
 [Getting Started](https://developers.ukfast.io/getting-started) section of the API documentation before 
 proceeding below
 
@@ -45,7 +45,7 @@ PowerShell:
 And away we go!
 
 ```
-> ukfast safedns zone record show example.co.uk 3337874
+> ans safedns zone record show example.co.uk 3337874
 +---------+--------------------+------+---------+---------------------------+----------+-----+
 |   ID    |        NAME        | TYPE | CONTENT |        UPDATED AT         | PRIORITY | TTL |
 +---------+--------------------+------+---------+---------------------------+----------+-----+
@@ -61,7 +61,7 @@ Both of these methods are explained below.
 ### Configuration File
 
 The configuration file is read from
-`$HOME/.ukfast{.extension}` by default (extension being one of the `viper` supported formats such as `yml`, `yaml`, `json`, `toml` etc.). This path can be overridden with the `--config` flag.
+`$HOME/.ans{.extension}` by default (extension being one of the `viper` supported formats such as `yml`, `yaml`, `json`, `toml` etc.). This path can be overridden with the `--config` flag.
 
 Values defined in the configuration file take precedence over environment variables.
 
@@ -95,9 +95,9 @@ The configuration file can be manipulated using the `config` subcommand, for exa
 
 
 ```
-> ukfast config context update --current --api-key test1
-> ukfast config context update someothercontext --api-key test1
-> ukfast config context switch someothercontext
+> ans config context update --current --api-key test1
+> ans config context update someothercontext --api-key test1
+> ans config context switch someothercontext
 ```
 
 ### Environment variables
@@ -116,13 +116,13 @@ The default output format for the CLI is `Table`, which will be used when the va
 is `table` or unspecified:
 
 ```
-> ukfast safedns zone record list example.co.uk
+> ans safedns zone record list example.co.uk
 +---------+--------------------+------+-----------------------------------------------------------------------+---------------------------+----------+-------+
 |   ID    |        NAME        | TYPE |                                CONTENT                                |        UPDATED AT         | PRIORITY |  TTL  |
 +---------+--------------------+------+-----------------------------------------------------------------------+---------------------------+----------+-------+
 | 3337865 | ns0.ukfast.net     | NS   | 185.226.220.128                                                       | 2019-03-19T16:31:48+00:00 |        0 |     0 |
 | 3337868 | ns1.ukfast.net     | NS   | 185.226.221.128                                                       | 2019-03-19T16:31:48+00:00 |        0 |     0 |
-| 3337871 | example.co.uk      | SOA  | ns0.ukfast.net support.ukfast.co.uk 2019031901 7200 3600 604800 86400 | 2019-03-19T16:31:48+00:00 |        0 | 86400 |
+| 3337871 | example.co.uk      | SOA  | ns0.ukfast.net support.ans.co.uk 2019031901 7200 3600 604800 86400 | 2019-03-19T16:31:48+00:00 |        0 | 86400 |
 | 3337874 | test.example.co.uk | A    | 1.2.3.4                                                               | 2019-03-19T16:33:55+00:00 |        0 |     0 |
 +---------+--------------------+------+-----------------------------------------------------------------------+---------------------------+----------+-------+
 ```
@@ -134,7 +134,7 @@ The [Property Modifier](#property) is available for this format
 Results can be output as a list using the `list` format:
 
 ```
-> ukfast safedns zone record show example.co.uk 3337874 --output list
+> ans safedns zone record show example.co.uk 3337874 --output list
 id         : 3337874
 name       : test.example.co.uk
 type       : A
@@ -151,7 +151,7 @@ The [Property Modifier](#property) is available for this format
 Results can be output in JSON using the `json` format:
 
 ```
-> ukfast safedns zone record show example.co.uk 3337874 --output json
+> ans safedns zone record show example.co.uk 3337874 --output json
 [{"id":3337874,"template_id":0,"name":"test.example.co.uk","type":"A","content":"1.2.3.4","updated_at":"2019-03-19T16:33:55+00:00","ttl":0,"priority":0}]
 ```
 
@@ -160,7 +160,7 @@ Results can be output in JSON using the `json` format:
 Results can be output in YAML using the `yaml` format:
 
 ```
-> ukfast safedns zone record show example.co.uk 3337874 --output yaml
+> ans safedns zone record show example.co.uk 3337874 --output yaml
 - id: 3337874
   templateid: 0
   name: test.example.co.uk
@@ -176,12 +176,12 @@ Results can be output in YAML using the `yaml` format:
 Results can be output with a value or set of values using the `value` format:
 
 ```
-> ukfast safedns zone record show example.co.uk 3337874 --output value
+> ans safedns zone record show example.co.uk 3337874 --output value
 3337874 test.example.co.uk A 1.2.3.4 2019-03-19T16:33:55+00:00 0 0
 ```
 
 ```
-> ukfast safedns zone record show example.co.uk 3337874 --output value --property id
+> ans safedns zone record show example.co.uk 3337874 --output value --property id
 3337874
 ```
 
@@ -192,7 +192,7 @@ The [Property Modifier](#property) is available for this format
 Results can be output as CSV using the `csv` format:
 
 ```
-> ukfast safedns zone record show example.co.uk 3337874 --output csv
+> ans safedns zone record show example.co.uk 3337874 --output csv
 id,name,type,content,updated_at,priority,ttl
 3337874,test.example.co.uk,A,1.2.3.4,2019-03-19T16:33:55+00:00,0,0
 ```
@@ -205,7 +205,7 @@ Results can be output using a supplied Golang template string using the `templat
 in conjunction with output arguments, e.g.
 
 ```
-> ukfast safedns zone record list example.co.uk --output template="Record name: {{ .Name }}, Type: {{ .Type }}"
+> ans safedns zone record list example.co.uk --output template="Record name: {{ .Name }}, Type: {{ .Type }}"
 Record name: ns0.ukfast.net, Type: NS
 Record name: ns1.ukfast.net, Type: NS
 Record name: example.co.uk, Type: SOA
@@ -218,7 +218,7 @@ Results can be output via JSON Path using the `jsonpath` format
 in conjunction with output arguments, e.g.
 
 ```
-> ukfast safedns zone record list example.co.uk --output jsonpath="{[*].name}"
+> ans safedns zone record list example.co.uk --output jsonpath="{[*].name}"
 example.co.uk example.co.uk example.co.uk test.example.co.uk
 ```
 
@@ -232,14 +232,14 @@ Some output formats support the `--property` output modifier.
 Required properties can be specified with the `--property` format modifer flag:
 
 ```
-> ukfast safedns zone record show example.co.uk 3337874 --output value --property name
+> ans safedns zone record show example.co.uk 3337874 --output value --property name
 test.example.co.uk
 ```
 
 The property modifier accepts a comma-delimited list of property names, and is also repeatable:
 
 ```
-> ukfast safedns zone record show example.co.uk 3337874 --output value --property id,name --property content
+> ans safedns zone record show example.co.uk 3337874 --output value --property id,name --property content
 3337874 test.example.co.uk 1.2.3.4
 ```
 
@@ -276,10 +276,10 @@ When using `list` commands, sorting is available via the `--sort` flag.
 The CLI has self-update functionality, which can be invoked via the command `update`:
 
 ```
-> ukfast update
+> ans update
 ```
 
-This command in-place updates the CLI, with the old binary moved to `ukfast.old` (`ukfast.old.exe` on Windows), should roll-back be required.
+This command in-place updates the CLI, with the old binary moved to `ans.old` (`ans.old.exe` on Windows), should roll-back be required.
 
 ## Shell autocompletions
 
@@ -289,7 +289,7 @@ The CLI supports generating shell completions for the following shells:
 * Zsh
 * PowerShell
 
-The commands at `ukfast completion <shell: bash|zsh|powershell>` provide help for installation on different platforms
+The commands at `ans completion <shell: bash|zsh|powershell>` provide help for installation on different platforms
 
 ## eCloud VPC resources
 

--- a/build.ps1
+++ b/build.ps1
@@ -20,7 +20,7 @@ switch ($OS)
     }
 }
 
-$output = "ukfast"
+$output = "ans"
 if ($env:GOOS -eq "windows" -or ([string]::IsNullOrEmpty($env:GOOS) -and $Env:OS -eq "Windows_NT"))
 {
     $output = $output+".exe"

--- a/cmd/account/account_contact.go
+++ b/cmd/account/account_contact.go
@@ -30,7 +30,7 @@ func accountContactListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists contacts",
 		Long:    "This command lists contacts",
-		Example: "ukfast account contact list",
+		Example: "ans account contact list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -61,7 +61,7 @@ func accountContactShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <contact: id>...",
 		Short:   "Shows a contact",
 		Long:    "This command shows one or more contacts",
-		Example: "ukfast account contact show 123",
+		Example: "ans account contact show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing contact")

--- a/cmd/account/account_credit.go
+++ b/cmd/account/account_credit.go
@@ -27,7 +27,7 @@ func accountCreditListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists credits",
 		Long:    "This command lists credits",
-		Example: "ukfast account credit list",
+		Example: "ans account credit list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {

--- a/cmd/account/account_details.go
+++ b/cmd/account/account_details.go
@@ -26,7 +26,7 @@ func accountDetailsShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show",
 		Short:   "Shows account details",
 		Long:    "This command shows account details",
-		Example: "ukfast account detail show",
+		Example: "ans account detail show",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {

--- a/cmd/billing/billing_card.go
+++ b/cmd/billing/billing_card.go
@@ -34,7 +34,7 @@ func billingCardListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists cards",
 		Long:    "This command lists cards",
-		Example: "ukfast billing card list",
+		Example: "ans billing card list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -65,7 +65,7 @@ func billingCardShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <card: id>...",
 		Short:   "Shows a card",
 		Long:    "This command shows one or more cards",
-		Example: "ukfast billing card show 123",
+		Example: "ans billing card show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing card")
@@ -110,7 +110,7 @@ func billingCardCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a card",
 		Long:    "This command creates a card",
-		Example: "ukfast billing card create",
+		Example: "ans billing card create",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -174,7 +174,7 @@ func billingCardUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <virtualmachine: id>...",
 		Short:   "Updates a card",
 		Long:    "This command updates one or more cards",
-		Example: "ukfast billing card update 123 --name \"test card 1\"",
+		Example: "ans billing card update 123 --name \"test card 1\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing card")
@@ -257,7 +257,7 @@ func billingCardDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <card: id>...",
 		Short:   "Removes a card",
 		Long:    "This command removes one or more cards",
-		Example: "ukfast billing card delete 123",
+		Example: "ans billing card delete 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing card")

--- a/cmd/billing/billing_cloudcost.go
+++ b/cmd/billing/billing_cloudcost.go
@@ -27,7 +27,7 @@ func billingCloudCostListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists cloud costs",
 		Long:    "This command lists cloud costs",
-		Example: "ukfast billing cloudcost list",
+		Example: "ans billing cloudcost list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {

--- a/cmd/billing/billing_directdebit.go
+++ b/cmd/billing/billing_directdebit.go
@@ -26,7 +26,7 @@ func billingDirectDebitShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show",
 		Short:   "Shows direct debit details",
 		Long:    "This command shows direct debit details",
-		Example: "ukfast billing directdebit show",
+		Example: "ans billing directdebit show",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {

--- a/cmd/billing/billing_invoice.go
+++ b/cmd/billing/billing_invoice.go
@@ -30,7 +30,7 @@ func billingInvoiceListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists invoices",
 		Long:    "This command lists invoices",
-		Example: "ukfast billing invoice list",
+		Example: "ans billing invoice list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -61,7 +61,7 @@ func billingInvoiceShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <invoice: id>...",
 		Short:   "Shows a invoice",
 		Long:    "This command shows one or more invoices",
-		Example: "ukfast billing invoice show 123",
+		Example: "ans billing invoice show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing invoice")

--- a/cmd/billing/billing_invoicequery.go
+++ b/cmd/billing/billing_invoicequery.go
@@ -31,7 +31,7 @@ func billingInvoiceQueryListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists invoice queries",
 		Long:    "This command lists invoice queries",
-		Example: "ukfast billing invoicequery list",
+		Example: "ans billing invoicequery list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -62,7 +62,7 @@ func billingInvoiceQueryShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <invoicequery: id>...",
 		Short:   "Shows an invoice query",
 		Long:    "This command shows one or more invoice queries",
-		Example: "ukfast billing invoicequery show 123",
+		Example: "ans billing invoicequery show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing invoice query")
@@ -107,7 +107,7 @@ func billingInvoiceQueryCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a invoice query",
 		Long:    "This command creates a new invoice query",
-		Example: "ukfast billing invoice query create",
+		Example: "ans billing invoice query create",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing invoice")

--- a/cmd/billing/billing_payment.go
+++ b/cmd/billing/billing_payment.go
@@ -30,7 +30,7 @@ func billingPaymentListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists payments",
 		Long:    "This command lists payments",
-		Example: "ukfast billing payment list",
+		Example: "ans billing payment list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -61,7 +61,7 @@ func billingPaymentShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <payment: id>...",
 		Short:   "Shows a payment",
 		Long:    "This command shows one or more payments",
-		Example: "ukfast billing payment show 123",
+		Example: "ans billing payment show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing payment")

--- a/cmd/billing/billing_recurringcost.go
+++ b/cmd/billing/billing_recurringcost.go
@@ -30,7 +30,7 @@ func billingRecurringCostListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists recurring costs",
 		Long:    "This command lists recurring costs",
-		Example: "ukfast billing recurringcost list",
+		Example: "ans billing recurringcost list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -61,7 +61,7 @@ func billingRecurringCostShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <recurringcost: id>...",
 		Short:   "Shows a recurring cost",
 		Long:    "This command shows one or more recurring costs",
-		Example: "ukfast billing recurringcost show 123",
+		Example: "ans billing recurringcost show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing recurring cost")

--- a/cmd/cloudflare/cloudflare_account.go
+++ b/cmd/cloudflare/cloudflare_account.go
@@ -34,7 +34,7 @@ func cloudflareAccountListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists accounts",
 		Long:    "This command lists accounts",
-		Example: "ukfast cloudflare account list",
+		Example: "ans cloudflare account list",
 		RunE:    cloudflareCobraRunEFunc(f, cloudflareAccountList),
 	}
 }
@@ -58,7 +58,7 @@ func cloudflareAccountShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <account: id>...",
 		Short:   "Shows a account",
 		Long:    "This command shows one or more accounts",
-		Example: "ukfast cloudflare account show e3f8baa0-b7c3-4a7a-958d-68e1aca3ea25",
+		Example: "ans cloudflare account show e3f8baa0-b7c3-4a7a-958d-68e1aca3ea25",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing account")
@@ -90,7 +90,7 @@ func cloudflareAccountCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates an account",
 		Long:    "This command creates an account",
-		Example: "ukfast cloudflare account create --name test",
+		Example: "ans cloudflare account create --name test",
 		RunE:    cloudflareCobraRunEFunc(f, cloudflareAccountCreate),
 	}
 
@@ -121,7 +121,7 @@ func cloudflareAccountUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <account: id>...",
 		Short:   "Updates an account",
 		Long:    "This command updates one or more accounts",
-		Example: "ukfast cloudflare account update e3f8baa0-b7c3-4a7a-958d-68e1aca3ea25",
+		Example: "ans cloudflare account update e3f8baa0-b7c3-4a7a-958d-68e1aca3ea25",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing account")

--- a/cmd/cloudflare/cloudflare_account_member.go
+++ b/cmd/cloudflare/cloudflare_account_member.go
@@ -26,7 +26,7 @@ func cloudflareAccountMemberCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates account members",
 		Long:    "This command creates account members",
-		Example: "ukfast cloudflare account member create e84d6820-870a-4d69-89a4-30e9f1016518",
+		Example: "ans cloudflare account member create e84d6820-870a-4d69-89a4-30e9f1016518",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing account")

--- a/cmd/cloudflare/cloudflare_orchestrator.go
+++ b/cmd/cloudflare/cloudflare_orchestrator.go
@@ -25,7 +25,7 @@ func cloudflareOrchestratorCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates an orchestration",
 		Long:    "This command creates an orchestration",
-		Example: "ukfast cloudflare orchestrator create --zone-name testzone --zone-subscription c46411f8-13e3-484e-a114-9d0ce5d53502 --account-name testaccount --administrator-email-address test@test.com",
+		Example: "ans cloudflare orchestrator create --zone-name testzone --zone-subscription c46411f8-13e3-484e-a114-9d0ce5d53502 --account-name testaccount --administrator-email-address test@test.com",
 		RunE:    cloudflareCobraRunEFunc(f, cloudflareOrchestratorCreate),
 	}
 

--- a/cmd/cloudflare/cloudflare_spendplan.go
+++ b/cmd/cloudflare/cloudflare_spendplan.go
@@ -27,7 +27,7 @@ func cloudflareSpendPlanListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists spend plans",
 		Long:    "This command lists spend plans",
-		Example: "ukfast cloudflare spendplan list",
+		Example: "ans cloudflare spendplan list",
 		RunE:    cloudflareCobraRunEFunc(f, cloudflareSpendPlanList),
 	}
 }

--- a/cmd/cloudflare/cloudflare_subscription.go
+++ b/cmd/cloudflare/cloudflare_subscription.go
@@ -27,7 +27,7 @@ func cloudflareSubscriptionListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists subscriptions",
 		Long:    "This command lists subscriptions",
-		Example: "ukfast cloudflare subscription list",
+		Example: "ans cloudflare subscription list",
 		RunE:    cloudflareCobraRunEFunc(f, cloudflareSubscriptionList),
 	}
 }

--- a/cmd/cloudflare/cloudflare_totalspend.go
+++ b/cmd/cloudflare/cloudflare_totalspend.go
@@ -26,7 +26,7 @@ func cloudflareTotalSpendShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show",
 		Short:   "Shows total spend",
 		Long:    "This command shows total spend",
-		Example: "ukfast cloudflare totalspend show",
+		Example: "ans cloudflare totalspend show",
 		RunE:    cloudflareCobraRunEFunc(f, cloudflareTotalSpendShow),
 	}
 }

--- a/cmd/cloudflare/cloudflare_zone.go
+++ b/cmd/cloudflare/cloudflare_zone.go
@@ -32,7 +32,7 @@ func cloudflareZoneListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists zones",
 		Long:    "This command lists zones",
-		Example: "ukfast cloudflare zone list",
+		Example: "ans cloudflare zone list",
 		RunE:    cloudflareCobraRunEFunc(f, cloudflareZoneList),
 	}
 }
@@ -56,7 +56,7 @@ func cloudflareZoneShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <zone: id>...",
 		Short:   "Shows a zone",
 		Long:    "This command shows one or more zones",
-		Example: "ukfast cloudflare zone show 00000000-0000-0000-0000-000000000000",
+		Example: "ans cloudflare zone show 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing zone")
@@ -88,7 +88,7 @@ func cloudflareZoneCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <zone: id>",
 		Short:   "Creates a zone",
 		Long:    "This command creates a zone",
-		Example: "ukfast cloudflare zone create --account 621e88d4-c401-4063-bdcf-07ca3c09efed --name \"test-zone\" --subscription a144257d-df53-414e-a44d-3dd84ac90395",
+		Example: "ans cloudflare zone create --account 621e88d4-c401-4063-bdcf-07ca3c09efed --name \"test-zone\" --subscription a144257d-df53-414e-a44d-3dd84ac90395",
 		RunE:    cloudflareCobraRunEFunc(f, cloudflareZoneCreate),
 	}
 
@@ -126,7 +126,7 @@ func cloudflareZoneUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <zone: id>...",
 		Short:   "Removes a zone",
 		Long:    "This command removes one or more zones",
-		Example: "ukfast cloudflare zone update 83d70af6-80ba-4463-abda-2880613efbc1",
+		Example: "ans cloudflare zone update 83d70af6-80ba-4463-abda-2880613efbc1",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing zone")
@@ -162,7 +162,7 @@ func cloudflareZoneDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <zone: id>...",
 		Short:   "Removes a zone",
 		Long:    "This command removes one or more zones",
-		Example: "ukfast cloudflare zone delete 1c3081b2-d65e-41d1-8077-c86f21759366",
+		Example: "ans cloudflare zone delete 1c3081b2-d65e-41d1-8077-c86f21759366",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing zone")

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -26,15 +26,15 @@ func completionBashCmd() *cobra.Command {
 		Short: "Generates bash completion scripts",
 		Long: `To load completion into current shell:
 
-source <(ukfast completion bash)
+source <(ans completion bash)
 
 To configure your bash shell to load completions for all sessions, add the above to ~/.bashrc as below:
 
-echo 'source <(ukfast completion bash)' >> ~/.bashrc
+echo 'source <(ans completion bash)' >> ~/.bashrc
 
 Alternatively, completions in /etc/bash_completion.d/ will be auto-loaded:
 
-echo 'source <(ukfast completion bash)' >> /etc/bash_completion.d/ukfast
+echo 'source <(ans completion bash)' >> /etc/bash_completion.d/ans
 `,
 		Run: func(cmd *cobra.Command, args []string) {
 			rootCmd.GenBashCompletion(os.Stdout)
@@ -48,13 +48,13 @@ func completionPowerShellCmd() *cobra.Command {
 		Short: "Generates Powershell completion scripts",
 		Long: `To load completion into current shell:
 
-Invoke-Expression -Command (ukfast completion powershell | Out-String)
+Invoke-Expression -Command (ans completion powershell | Out-String)
 
 To configure your shell to load completions for each session, output completion to profile:
 
 $ProfileDIR = Split-Path -Parent -Path $PROFILE
-$CompletionPath = [System.IO.Path]::GetFullPath("$ProfileDIR/ukfast.completion.ps1")
-Out-File -Append -FilePath $CompletionPath -Encoding ASCII -InputObject "Invoke-Expression -Command (ukfast completion powershell | Out-String)"
+$CompletionPath = [System.IO.Path]::GetFullPath("$ProfileDIR/ans.completion.ps1")
+Out-File -Append -FilePath $CompletionPath -Encoding ASCII -InputObject "Invoke-Expression -Command (ans completion powershell | Out-String)"
 Out-File -Append -FilePath $PROFILE -Encoding ASCII -InputObject ` + "\"`n. $CompletionPath\"",
 		Run: func(cmd *cobra.Command, args []string) {
 			rootCmd.GenPowerShellCompletion(os.Stdout)
@@ -68,11 +68,11 @@ func completionZshCmd() *cobra.Command {
 		Short: "Generates zsh completion scripts",
 		Long: `To load completion into current shell:
 
-source <(ukfast completion zsh)
+source <(ans completion zsh)
 
 To configure your zsh shell to load completions for all sessions, completions in /etc/bash_completion.d/ will be auto-loaded:
 
-echo 'source <(ukfast completion zsh)' >> /etc/bash_completion.d/ukfast
+echo 'source <(ans completion zsh)' >> /etc/bash_completion.d/ans
 `,
 		Run: func(cmd *cobra.Command, args []string) {
 			rootCmd.GenZshCompletion(os.Stdout)

--- a/cmd/config/config_context.go
+++ b/cmd/config/config_context.go
@@ -30,7 +30,7 @@ func configContextUpdateCmd(fs afero.Fs) *cobra.Command {
 		Use:     "update",
 		Short:   "Updates context configuration",
 		Long:    "This command updates context configuration",
-		Example: "ukfast config context update mycontext --api-key \"secretkey\"",
+		Example: "ans config context update mycontext --api-key \"secretkey\"",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return configContextUpdate(fs, cmd, args)
 		},
@@ -101,7 +101,7 @@ func configContextListCmd() *cobra.Command {
 		Use:     "list",
 		Short:   "Lists contexts",
 		Long:    "This command lists contexts",
-		Example: "ukfast config context list",
+		Example: "ans config context list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return configContextList(cmd)
 		},
@@ -142,7 +142,7 @@ func configContextSwitchCmd(fs afero.Fs) *cobra.Command {
 		Use:     "switch",
 		Short:   "Switches current context",
 		Long:    "This command switches the current context",
-		Example: "ukfast config context switch mycontext",
+		Example: "ans config context switch mycontext",
 		Aliases: []string{"use"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {

--- a/cmd/ddosx/ddosx_domain.go
+++ b/cmd/ddosx/ddosx_domain.go
@@ -43,7 +43,7 @@ func ddosxDomainListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists domains",
 		Long:    "This command lists domains",
-		Example: "ukfast ddosx domain list",
+		Example: "ans ddosx domain list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -74,7 +74,7 @@ func ddosxDomainShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <domain: name>...",
 		Short:   "Shows a domain",
 		Long:    "This command shows one or more domains",
-		Example: "ukfast ddosx domain show example.com",
+		Example: "ans ddosx domain show example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -113,7 +113,7 @@ func ddosxDomainCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a domain",
 		Long:    "This command creates a new domain",
-		Example: "ukfast ddosx domain create --name example.com",
+		Example: "ans ddosx domain create --name example.com",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -156,7 +156,7 @@ func ddosxDomainDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <domain: name>...",
 		Short:   "Deletes a domain",
 		Long:    "This command deletes one or more domains",
-		Example: "ukfast ddosx domain delete example.com",
+		Example: "ans ddosx domain delete example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -202,7 +202,7 @@ func ddosxDomainDeployCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "deploy <domain: name>...",
 		Short:   "Deploys a domain",
 		Long:    "This command deploys one or more domains",
-		Example: "ukfast ddosx domain deploy example.com",
+		Example: "ans ddosx domain deploy example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_domain_acl_geoip.go
+++ b/cmd/ddosx/ddosx_domain_acl_geoip.go
@@ -35,7 +35,7 @@ func ddosxDomainACLGeoIPRuleListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <domain: name>",
 		Short:   "Lists ACL GeoIP rules",
 		Long:    "This command lists domain ACL GeoIP rules",
-		Example: "ukfast ddosx domain acl geoip list",
+		Example: "ans ddosx domain acl geoip list",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -73,7 +73,7 @@ func ddosxDomainACLGeoIPRuleShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <domain: name> <rule: id>...",
 		Short:   "Shows domain ACL GeoIP rules",
 		Long:    "This command shows an ACL GeoIP rule",
-		Example: "ukfast ddosx domain acl geoip show example.com 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx domain acl geoip show example.com 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -117,7 +117,7 @@ func ddosxDomainACLGeoIPRuleCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <domain: name>",
 		Short:   "Creates ACL GeoIP rules",
 		Long:    "This command creates domain ACL GeoIP rules",
-		Example: "ukfast ddosx domain acl geoip create example.com --code gb",
+		Example: "ans ddosx domain acl geoip create example.com --code gb",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -164,7 +164,7 @@ func ddosxDomainACLGeoIPRuleUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <domain: name> <rule: id>...",
 		Short:   "Updates ACL GeoIP rules",
 		Long:    "This command updates one or more domain ACL GeoIP rules",
-		Example: "ukfast ddosx domain acl geoip update example.com 00000000-0000-0000-0000-000000000000 --code GB",
+		Example: "ans ddosx domain acl geoip update example.com 00000000-0000-0000-0000-000000000000 --code GB",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -222,7 +222,7 @@ func ddosxDomainACLGeoIPRuleDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <domain: name> <rule: id>...",
 		Short:   "Deletes ACL GeoIP rules",
 		Long:    "This command deletes one or more domain ACL GeoIP rules",
-		Example: "ukfast ddosx domain acl geoip delete example.com 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx domain acl geoip delete example.com 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_domain_acl_geoip_mode.go
+++ b/cmd/ddosx/ddosx_domain_acl_geoip_mode.go
@@ -28,7 +28,7 @@ func ddosxDomainACLGeoIPRulesModeShowCmd(f factory.ClientFactory) *cobra.Command
 		Use:     "show <domain: name>...",
 		Short:   "Shows a domain",
 		Long:    "This command shows one or more domains",
-		Example: "ukfast ddosx domain show example.com",
+		Example: "ans ddosx domain show example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -67,7 +67,7 @@ func ddosxDomainACLGeoIPRulesModeUpdateCmd(f factory.ClientFactory) *cobra.Comma
 		Use:     "update <domain: name>",
 		Short:   "Updates a domain ACL GeoIP rule filtering mode",
 		Long:    "This command updates a domain ACL GeoIP rule filtering mode",
-		Example: "ukfast ddosx domain acl geoip mode update example.com --mode whitelist",
+		Example: "ans ddosx domain acl geoip mode update example.com --mode whitelist",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_domain_acl_ip.go
+++ b/cmd/ddosx/ddosx_domain_acl_ip.go
@@ -36,7 +36,7 @@ func ddosxDomainACLIPRuleListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <domain: name>",
 		Short:   "Lists ACL IP rules",
 		Long:    "This command lists domain ACL IP rules",
-		Example: "ukfast ddosx domain acl ip list",
+		Example: "ans ddosx domain acl ip list",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -74,7 +74,7 @@ func ddosxDomainACLIPRuleShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <domain: name> <rule: id>...",
 		Short:   "Shows domain ACL IP rules",
 		Long:    "This command shows an ACL IP rule",
-		Example: "ukfast ddosx domain acl ip show example.com 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx domain acl ip show example.com 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -118,7 +118,7 @@ func ddosxDomainACLIPRuleCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <domain: name>",
 		Short:   "Creates ACL IP rules",
 		Long:    "This command creates domain ACL IP rules",
-		Example: "ukfast ddosx domain acl ip create example.com --ip 1.2.3.4 --mode Deny --uri blog",
+		Example: "ans ddosx domain acl ip create example.com --ip 1.2.3.4 --mode Deny --uri blog",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -176,7 +176,7 @@ func ddosxDomainACLIPRuleUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <domain: name> <rule: id>...",
 		Short:   "Updates ACL IP rules",
 		Long:    "This command updates one or more domain ACL IP rules",
-		Example: "ukfast ddosx domain acl ip update example.com 00000000-0000-0000-0000-000000000000 --ip 1.2.3.4",
+		Example: "ans ddosx domain acl ip update example.com 00000000-0000-0000-0000-000000000000 --ip 1.2.3.4",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -251,7 +251,7 @@ func ddosxDomainACLIPRuleDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <domain: name> <rule: id>...",
 		Short:   "Deletes ACL IP rules",
 		Long:    "This command deletes one or more domain ACL IP rules",
-		Example: "ukfast ddosx domain acl ip delete example.com 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx domain acl ip delete example.com 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_domain_cdn.go
+++ b/cmd/ddosx/ddosx_domain_cdn.go
@@ -32,7 +32,7 @@ func ddosxDomainCDNEnableCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "enable <domain: name>...",
 		Short:   "Enables CDN for a domain",
 		Long:    "This command enables CDN for one or more domains",
-		Example: "ukfast ddosx domain cdn enable example.com",
+		Example: "ans ddosx domain cdn enable example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -78,7 +78,7 @@ func ddosxDomainCDNDisableCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "disable <domain: name>...",
 		Short:   "Disables CDN for a domain",
 		Long:    "This command disables CDN for one or more domains",
-		Example: "ukfast ddosx domain cdn disable example.com",
+		Example: "ans ddosx domain cdn disable example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -124,7 +124,7 @@ func ddosxDomainCDNPurgeCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "purge <domain: name>",
 		Short:   "Purges CDN content for a domain",
 		Long:    "This command purges CDN content for a domain",
-		Example: "ukfast ddosx domain cdn purge example.com --record-name something.example.com --uri /test",
+		Example: "ans ddosx domain cdn purge example.com --record-name something.example.com --uri /test",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_domain_cdn_rule.go
+++ b/cmd/ddosx/ddosx_domain_cdn_rule.go
@@ -33,7 +33,7 @@ func ddosxDomainCDNRuleListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <domain: name>",
 		Short:   "Lists domain CDN rules",
 		Long:    "This command lists CDN rules",
-		Example: "ukfast ddosx domain cdn rule list",
+		Example: "ans ddosx domain cdn rule list",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -71,7 +71,7 @@ func ddosxDomainCDNRuleShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <domain: name> <rule: id>...",
 		Short:   "Shows CDN rules",
 		Long:    "This command shows one or more CDN rules",
-		Example: "ukfast ddosx domain cdn rule show example.com 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx domain cdn rule show example.com 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -113,7 +113,7 @@ func ddosxDomainCDNRuleCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <domain: name>",
 		Short:   "Creates domain CDN rules",
 		Long:    "This command creates domain CDN rules",
-		Example: "ukfast ddosx domain cdn rule create example.com --uri example.html --cache-control custom --mime-type image/* --type global",
+		Example: "ans ddosx domain cdn rule create example.com --uri example.html --cache-control custom --mime-type image/* --type global",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -191,7 +191,7 @@ func ddosxDomainCDNRuleUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <domain: name> <rule: id>...",
 		Short:   "Updates CDN rules",
 		Long:    "This command updates one or more domain CDN rules",
-		Example: "ukfast ddosx domain cdn rule update example.com 00000000-0000-0000-0000-000000000000 --mime-type image/*",
+		Example: "ans ddosx domain cdn rule update example.com 00000000-0000-0000-0000-000000000000 --mime-type image/*",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -288,7 +288,7 @@ func ddosxDomainCDNRuleDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <domain: name> <rule: id>...",
 		Short:   "Deletes CDN rules",
 		Long:    "This command deletes one or more domain CDN rules",
-		Example: "ukfast ddosx domain cdn rule delete example.com 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx domain cdn rule delete example.com 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_domain_dns.go
+++ b/cmd/ddosx/ddosx_domain_dns.go
@@ -27,7 +27,7 @@ func ddosxDomainDNSActivateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "activate <domain: name>...",
 		Short:   "Activates DNS routing for a domain",
 		Long:    "This command activates DNS routing for one or more domains",
-		Example: "ukfast ddosx domain dns activate example.com",
+		Example: "ans ddosx domain dns activate example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -72,7 +72,7 @@ func ddosxDomainDNSDeactivateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "deactivate <domain: name>...",
 		Short:   "Deactivates DNS routing for a domain",
 		Long:    "This command deactivates DNS routing for one or more domains",
-		Example: "ukfast ddosx domain dns deactivate example.com",
+		Example: "ans ddosx domain dns deactivate example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_domain_hsts.go
+++ b/cmd/ddosx/ddosx_domain_hsts.go
@@ -31,7 +31,7 @@ func ddosxDomainHSTSShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <domain: name>...",
 		Short:   "Shows HSTS for a domain",
 		Long:    "This command shows HSTS for one or more domains",
-		Example: "ukfast ddosx domain hsts show example.com",
+		Example: "ans ddosx domain hsts show example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -71,7 +71,7 @@ func ddosxDomainHSTSEnableCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "enable <domain: name>...",
 		Short:   "Enables HSTS for a domain",
 		Long:    "This command enables HSTS for one or more domains",
-		Example: "ukfast ddosx domain hsts enable example.com",
+		Example: "ans ddosx domain hsts enable example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -117,7 +117,7 @@ func ddosxDomainHSTSDisableCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "disable <domain: name>...",
 		Short:   "Disables HSTS for a domain",
 		Long:    "This command disables HSTS for one or more domains",
-		Example: "ukfast ddosx domain hsts disable example.com",
+		Example: "ans ddosx domain hsts disable example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_domain_hsts_rule.go
+++ b/cmd/ddosx/ddosx_domain_hsts_rule.go
@@ -33,7 +33,7 @@ func ddosxDomainHSTSRuleListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <domain: name>",
 		Short:   "Lists domain HSTS rules",
 		Long:    "This command lists HSTS rules",
-		Example: "ukfast ddosx domain hsts rule list",
+		Example: "ans ddosx domain hsts rule list",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -71,7 +71,7 @@ func ddosxDomainHSTSRuleShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <domain: name> <rule: id>...",
 		Short:   "Shows HSTS rules",
 		Long:    "This command shows one or more HSTS rules",
-		Example: "ukfast ddosx domain hsts rule show example.com 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx domain hsts rule show example.com 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -113,7 +113,7 @@ func ddosxDomainHSTSRuleCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <domain: name>",
 		Short:   "Creates domain HSTS rules",
 		Long:    "This command creates domain HSTS rules",
-		Example: "ukfast ddosx domain hsts rule create example.com --uri example.html --cache-control custom --mime-type image/* --type global",
+		Example: "ans ddosx domain hsts rule create example.com --uri example.html --cache-control custom --mime-type image/* --type global",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -177,7 +177,7 @@ func ddosxDomainHSTSRuleUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <domain: name> <rule: id>...",
 		Short:   "Updates HSTS rules",
 		Long:    "This command updates one or more domain HSTS rules",
-		Example: "ukfast ddosx domain hsts rule update example.com 00000000-0000-0000-0000-000000000000 --mime-type image/*",
+		Example: "ans ddosx domain hsts rule update example.com 00000000-0000-0000-0000-000000000000 --mime-type image/*",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -248,7 +248,7 @@ func ddosxDomainHSTSRuleDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <domain: name> <rule: id>...",
 		Short:   "Deletes HSTS rules",
 		Long:    "This command deletes one or more domain HSTS rules",
-		Example: "ukfast ddosx domain hsts rule delete example.com 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx domain hsts rule delete example.com 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_domain_property.go
+++ b/cmd/ddosx/ddosx_domain_property.go
@@ -31,7 +31,7 @@ func ddosxDomainPropertyListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <domain: name>",
 		Short:   "Lists domain properties",
 		Long:    "This command lists domain properties",
-		Example: "ukfast ddosx domain property list example.com",
+		Example: "ans ddosx domain property list example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -73,7 +73,7 @@ func ddosxDomainPropertyShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <domain: name>",
 		Short:   "Shows domain properties",
 		Long:    "This command shows a domain property",
-		Example: "ukfast ddosx domain property show example.com 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx domain property show example.com 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -117,7 +117,7 @@ func ddosxDomainPropertyUpdateCmd(f factory.ClientFactory, fs afero.Fs) *cobra.C
 		Use:     "update <domain: name>...",
 		Short:   "Updates domain properties",
 		Long:    "This command updates one or more domain properties",
-		Example: "ukfast ddosx domain property update example.com 00000000-0000-0000-0000-000000000000 --value false",
+		Example: "ans ddosx domain property update example.com 00000000-0000-0000-0000-000000000000 --value false",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_domain_record.go
+++ b/cmd/ddosx/ddosx_domain_record.go
@@ -32,7 +32,7 @@ func ddosxDomainRecordListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <domain: name>",
 		Short:   "Lists domain records",
 		Long:    "This command lists domain record",
-		Example: "ukfast ddosx domain record list example.com",
+		Example: "ans ddosx domain record list example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -70,7 +70,7 @@ func ddosxDomainRecordShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <domain: name> <record: id>...",
 		Short:   "Shows domain records",
 		Long:    "This command shows a domain record",
-		Example: "ukfast ddosx domain record show example.com 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx domain record show example.com 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -114,7 +114,7 @@ func ddosxDomainRecordCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <domain: name>",
 		Short:   "Creates a domain record",
 		Long:    "This command creates a new domain record",
-		Example: "ukfast ddosx domain record create example.com --name sub.example.com --type A",
+		Example: "ans ddosx domain record create example.com --name sub.example.com --type A",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -176,7 +176,7 @@ func ddosxDomainRecordUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <domain: name>...",
 		Short:   "Updates a domain record",
 		Long:    "This command updates one or more domain records",
-		Example: "ukfast ddosx domain record update example.com 00000000-0000-0000-0000-000000000000 --content 1.2.3.4",
+		Example: "ans ddosx domain record update example.com 00000000-0000-0000-0000-000000000000 --content 1.2.3.4",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -252,7 +252,7 @@ func ddosxDomainRecordDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <domain: name>...",
 		Short:   "Deletes a domain record",
 		Long:    "This command deletes one or more domain records",
-		Example: "ukfast ddosx domain record delete example.com 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx domain record delete example.com 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_domain_verification_dns.go
+++ b/cmd/ddosx/ddosx_domain_verification_dns.go
@@ -26,7 +26,7 @@ func ddosxDomainVerificationDNSVerifyCmd(f factory.ClientFactory) *cobra.Command
 		Use:     "verify <domain: name>...",
 		Short:   "Verifies a domain via DNS verification method",
 		Long:    "This command verifies one or more domains via the DNS verification method",
-		Example: "ukfast ddosx domain verification dns verify example.com",
+		Example: "ans ddosx domain verification dns verify example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_domain_verification_fileupload.go
+++ b/cmd/ddosx/ddosx_domain_verification_fileupload.go
@@ -34,7 +34,7 @@ func ddosxDomainVerificationFileUploadShowCmd(f factory.ClientFactory) *cobra.Co
 		Use:     "show <domain: name>...",
 		Short:   "Shows the verification file for a domain",
 		Long:    "This command shows the verification file for one or more domains, for use with the file upload verification method",
-		Example: "ukfast ddosx domain verification fileupload show example.com",
+		Example: "ans ddosx domain verification fileupload show example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -77,7 +77,7 @@ func ddosxDomainVerificationFileUploadDownloadCmd(f factory.ClientFactory, fs af
 		Use:     "download <domain: name>",
 		Short:   "Downloads the verification file for a domain",
 		Long:    "This command downloads the verification file for a domain, for use with the file upload verification method",
-		Example: "ukfast ddosx domain verification fileupload download example.com",
+		Example: "ans ddosx domain verification fileupload download example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -130,7 +130,7 @@ func ddosxDomainVerificationFileUploadVerifyCmd(f factory.ClientFactory) *cobra.
 		Use:     "verify <domain: name>...",
 		Short:   "Verifies a domain via verification file method",
 		Long:    "This command verifies one or more domains via the verification file method",
-		Example: "ukfast ddosx domain verification fileupload verify example.com",
+		Example: "ans ddosx domain verification fileupload verify example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_domain_waf.go
+++ b/cmd/ddosx/ddosx_domain_waf.go
@@ -35,7 +35,7 @@ func ddosxDomainWAFShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <domain: name>...",
 		Short:   "Shows a domain WAF",
 		Long:    "This command shows one or more domain WAFs",
-		Example: "ukfast ddosx domain waf show example.com",
+		Example: "ans ddosx domain waf show example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -74,7 +74,7 @@ func ddosxDomainWAFCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <domain: name>",
 		Short:   "Creates a domain WAF",
 		Long:    "This command creates a domain WAF",
-		Example: "ukfast ddosx domain waf create example.com --mode on --paranoia-level high",
+		Example: "ans ddosx domain waf create example.com --mode on --paranoia-level high",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -135,7 +135,7 @@ func ddosxDomainWAFUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <domain: name>..",
 		Short:   "Updates a domain WAF",
 		Long:    "This command updates one or more domain WAFs",
-		Example: "ukfast ddosx domain waf update example.com --mode on",
+		Example: "ans ddosx domain waf update example.com --mode on",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -207,7 +207,7 @@ func ddosxDomainWAFDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <domain: name>...",
 		Short:   "Deletes a domain WAF",
 		Long:    "This command deletes one or more domain WAFs",
-		Example: "ukfast ddosx domain waf delete example.com",
+		Example: "ans ddosx domain waf delete example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_domain_waf_advancedrule.go
+++ b/cmd/ddosx/ddosx_domain_waf_advancedrule.go
@@ -34,7 +34,7 @@ func ddosxDomainWAFAdvancedRuleListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <domain: name>",
 		Short:   "Lists domain WAF advanced rules",
 		Long:    "This command lists domain WAF advanced rules",
-		Example: "ukfast ddosx domain waf advancedrule list",
+		Example: "ans ddosx domain waf advancedrule list",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -72,7 +72,7 @@ func ddosxDomainWAFAdvancedRuleShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <domain: name> <rule: id>...",
 		Short:   "Shows domain WAF advanced rules",
 		Long:    "This command shows a WAF advanced rule",
-		Example: "ukfast ddosx domain waf advancedrule show example.com 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx domain waf advancedrule show example.com 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -116,7 +116,7 @@ func ddosxDomainWAFAdvancedRuleCreateCmd(f factory.ClientFactory) *cobra.Command
 		Use:     "create <domain: name>",
 		Short:   "Creates domain WAF advanced rules",
 		Long:    "This command creates domain WAF advanced rules",
-		Example: "ukfast ddosx domain waf advancedrule create --section REQUEST_URI --modifier beginswith --phrase test --ip 1.2.3.4",
+		Example: "ans ddosx domain waf advancedrule create --section REQUEST_URI --modifier beginswith --phrase test --ip 1.2.3.4",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -179,7 +179,7 @@ func ddosxDomainWAFAdvancedRuleUpdateCmd(f factory.ClientFactory) *cobra.Command
 		Use:     "update <domain: name> <advancedrule: id>...",
 		Short:   "Updates domain WAF advanced rules",
 		Long:    "This command updates one or more domain WAF advanced rules",
-		Example: "ukfast ddosx domain waf advancedrule update example.com 00000000-0000-0000-0000-000000000000 --ip 1.2.3.4",
+		Example: "ans ddosx domain waf advancedrule update example.com 00000000-0000-0000-0000-000000000000 --ip 1.2.3.4",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -256,7 +256,7 @@ func ddosxDomainWAFAdvancedRuleDeleteCmd(f factory.ClientFactory) *cobra.Command
 		Use:     "delete <domain: name> <advancedrule: id>...",
 		Short:   "Deletes domain WAF advanced rules",
 		Long:    "This command deletes one or more domain WAF advanced rules",
-		Example: "ukfast ddosx domain waf advancedrule delete example.com 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx domain waf advancedrule delete example.com 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_domain_waf_rule.go
+++ b/cmd/ddosx/ddosx_domain_waf_rule.go
@@ -34,7 +34,7 @@ func ddosxDomainWAFRuleListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <domain: name>",
 		Short:   "Lists domain WAF rules",
 		Long:    "This command lists WAF rules",
-		Example: "ukfast ddosx domain waf rule list",
+		Example: "ans ddosx domain waf rule list",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -72,7 +72,7 @@ func ddosxDomainWAFRuleShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <domain: name> <rule: id>...",
 		Short:   "Shows domain WAF rules",
 		Long:    "This command shows a WAF rule",
-		Example: "ukfast ddosx domain waf rule show example.com 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx domain waf rule show example.com 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -116,7 +116,7 @@ func ddosxDomainWAFRuleCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <domain: name>",
 		Short:   "Creates domain WAF rules",
 		Long:    "This command creates domain WAF rules",
-		Example: "ukfast ddosx domain waf rule create example.com --uri example.html --ip 1.2.3.4",
+		Example: "ans ddosx domain waf rule create example.com --uri example.html --ip 1.2.3.4",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -167,7 +167,7 @@ func ddosxDomainWAFRuleUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <domain: name> <ruleset: id>...",
 		Short:   "Updates WAF rules",
 		Long:    "This command updates one or more domain WAF rules",
-		Example: "ukfast ddosx domain waf ruleset update example.com 00000000-0000-0000-0000-000000000000 --active=true",
+		Example: "ans ddosx domain waf ruleset update example.com 00000000-0000-0000-0000-000000000000 --active=true",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -231,7 +231,7 @@ func ddosxDomainWAFRuleDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <domain: name> <rule: id>...",
 		Short:   "Deletes WAF rules",
 		Long:    "This command deletes one or more domain WAF rules",
-		Example: "ukfast ddosx domain waf rule delete example.com 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx domain waf rule delete example.com 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_domain_waf_ruleset.go
+++ b/cmd/ddosx/ddosx_domain_waf_ruleset.go
@@ -31,7 +31,7 @@ func ddosxDomainWAFRuleSetListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <domain: name>",
 		Short:   "Lists WAF rule sets",
 		Long:    "This command lists WAF rule sets",
-		Example: "ukfast ddosx domain waf ruleset list",
+		Example: "ans ddosx domain waf ruleset list",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -69,7 +69,7 @@ func ddosxDomainWAFRuleSetShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <domain: name> <ruleset: id>...",
 		Short:   "Shows WAF rule sets",
 		Long:    "This command shows one or more domain WAF rule sets",
-		Example: "ukfast ddosx domain waf ruleset show example.com 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx domain waf ruleset show example.com 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")
@@ -111,7 +111,7 @@ func ddosxDomainWAFRuleSetUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <domain: name> <ruleset: id>...",
 		Short:   "Updates WAF rule sets",
 		Long:    "This command updates one or more domain WAF rule sets",
-		Example: "ukfast ddosx domain waf ruleset update example.com 00000000-0000-0000-0000-000000000000 --active=true",
+		Example: "ans ddosx domain waf ruleset update example.com 00000000-0000-0000-0000-000000000000 --active=true",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ddosx/ddosx_record.go
+++ b/cmd/ddosx/ddosx_record.go
@@ -27,7 +27,7 @@ func ddosxRecordListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists records",
 		Long:    "This command lists records",
-		Example: "ukfast ddosx record list",
+		Example: "ans ddosx record list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {

--- a/cmd/ddosx/ddosx_ssl.go
+++ b/cmd/ddosx/ddosx_ssl.go
@@ -37,7 +37,7 @@ func ddosxSSLListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists ssls",
 		Long:    "This command lists ssls",
-		Example: "ukfast ddosx ssl list",
+		Example: "ans ddosx ssl list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -68,7 +68,7 @@ func ddosxSSLShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <ssl: id>...",
 		Short:   "Shows a ssl",
 		Long:    "This command shows one or more ssls",
-		Example: "ukfast ddosx ssl show 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx ssl show 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing ssl")
@@ -107,7 +107,7 @@ func ddosxSSLCreateCmd(f factory.ClientFactory, fs afero.Fs) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates an ssl",
 		Long:    "This command creates an SSL",
-		Example: "ukfast ddosx ssl create",
+		Example: "ans ddosx ssl create",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -171,7 +171,7 @@ func ddosxSSLUpdateCmd(f factory.ClientFactory, fs afero.Fs) *cobra.Command {
 		Use:     "update <ssl: id>",
 		Short:   "Updates an ssl",
 		Long:    "This command updates an SSL",
-		Example: "ukfast ddosx ssl update 00000000-0000-0000-0000-000000000000 --friendly-name myssl",
+		Example: "ans ddosx ssl update 00000000-0000-0000-0000-000000000000 --friendly-name myssl",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing ssl")
@@ -243,7 +243,7 @@ func ddosxSSLDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <ssl: id>...",
 		Short:   "Deletes a ssl",
 		Long:    "This command deletes one or more ssls",
-		Example: "ukfast ddosx ssl delete 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx ssl delete 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing ssl")

--- a/cmd/ddosx/ddosx_ssl_content.go
+++ b/cmd/ddosx/ddosx_ssl_content.go
@@ -26,7 +26,7 @@ func ddosxSSLContentShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <ssl: id>...",
 		Short:   "Shows a ssl's content",
 		Long:    "This command shows one or more ssl's content",
-		Example: "ukfast ddosx ssl content show 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx ssl content show 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing ssl")

--- a/cmd/ddosx/ddosx_ssl_privatekey.go
+++ b/cmd/ddosx/ddosx_ssl_privatekey.go
@@ -26,7 +26,7 @@ func ddosxSSLPrivateKeyShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <ssl: id>...",
 		Short:   "Shows a ssl's private key",
 		Long:    "This command shows one or more ssl's private key",
-		Example: "ukfast ddosx ssl privatekey show 00000000-0000-0000-0000-000000000000",
+		Example: "ans ddosx ssl privatekey show 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing ssl")

--- a/cmd/ddosx/ddosx_waf_log.go
+++ b/cmd/ddosx/ddosx_waf_log.go
@@ -32,7 +32,7 @@ func ddosxWAFLogListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists WAF logs",
 		Long:    "This command lists WAF logs",
-		Example: "ukfast ddosx waf log list",
+		Example: "ans ddosx waf log list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -67,7 +67,7 @@ func ddosxWAFLogShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <log: id>...",
 		Short:   "Shows WAF logs",
 		Long:    "This command shows a WAF log",
-		Example: "ukfast ddosx waf log show 2d8556677081cecf112b555c359a78c6",
+		Example: "ans ddosx waf log show 2d8556677081cecf112b555c359a78c6",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing log")

--- a/cmd/ddosx/ddosx_waf_log_match.go
+++ b/cmd/ddosx/ddosx_waf_log_match.go
@@ -30,7 +30,7 @@ func ddosxWAFLogMatchListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists WAF log matches",
 		Long:    "This command lists WAF log matches",
-		Example: "ukfast ddosx waf log match list",
+		Example: "ans ddosx waf log match list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -74,7 +74,7 @@ func ddosxWAFLogMatchShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <log: id> <match: id>...",
 		Short:   "Shows WAF log matches",
 		Long:    "This command shows a WAF log matches",
-		Example: "ukfast ddosx waf log match show 2d8556677081cecf112b555c359a78c6 123456",
+		Example: "ans ddosx waf log match show 2d8556677081cecf112b555c359a78c6 123456",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing log")

--- a/cmd/draas/draas_billingtype.go
+++ b/cmd/draas/draas_billingtype.go
@@ -29,7 +29,7 @@ func draasBillingTypeListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists billing types",
 		Long:    "This command lists billing types",
-		Example: "ukfast draas billingtype list",
+		Example: "ans draas billingtype list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -60,7 +60,7 @@ func draasBillingTypeShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <billingtype: id>...",
 		Short:   "Shows a billing type",
 		Long:    "This command shows one or more billing types",
-		Example: "ukfast draas billingtype show 00000000-0000-0000-0000-000000000000",
+		Example: "ans draas billingtype show 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing billing type")

--- a/cmd/draas/draas_iopstier.go
+++ b/cmd/draas/draas_iopstier.go
@@ -29,7 +29,7 @@ func draasIOPSTierListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists available IOPS tiers",
 		Long:    "This command lists available IOPS tiers",
-		Example: "ukfast draas iopstier list",
+		Example: "ans draas iopstier list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -60,7 +60,7 @@ func draasIOPSTierShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <iopstier: id>...",
 		Short:   "Shows an IOPS tier",
 		Long:    "This command shows one or more IOPS tiers",
-		Example: "ukfast draas iopstier show 00000000-0000-0000-0000-000000000000",
+		Example: "ans draas iopstier show 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing IOPS tier")

--- a/cmd/draas/draas_solution.go
+++ b/cmd/draas/draas_solution.go
@@ -37,7 +37,7 @@ func draasSolutionListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists solutions",
 		Long:    "This command lists solutions",
-		Example: "ukfast draas solution list",
+		Example: "ans draas solution list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -68,7 +68,7 @@ func draasSolutionShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <solution: id>...",
 		Short:   "Shows a solution",
 		Long:    "This command shows one or more solutions",
-		Example: "ukfast draas solution show 00000000-0000-0000-0000-000000000000",
+		Example: "ans draas solution show 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")
@@ -107,7 +107,7 @@ func draasSolutionUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <solution: id>",
 		Short:   "Updates a solution",
 		Long:    "This command updates a solution",
-		Example: "ukfast draas solution update 00000000-0000-0000-0000-000000000000 --name test",
+		Example: "ans draas solution update 00000000-0000-0000-0000-000000000000 --name test",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/draas/draas_solution_backupresource.go
+++ b/cmd/draas/draas_solution_backupresource.go
@@ -30,7 +30,7 @@ func draasSolutionBackupResourceListCmd(f factory.ClientFactory) *cobra.Command 
 		Use:     "list <solution: id>",
 		Short:   "Lists a solution",
 		Long:    "This command lists the backup resources for a solution",
-		Example: "ukfast draas solution backupresource list 00000000-0000-0000-0000-000000000000",
+		Example: "ans draas solution backupresource list 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/draas/draas_solution_backupservice.go
+++ b/cmd/draas/draas_solution_backupservice.go
@@ -28,7 +28,7 @@ func draasSolutionBackupServiceShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <solution: id>",
 		Short:   "Shows the backup service for a solution",
 		Long:    "This command shows the backup service for a solution",
-		Example: "ukfast draas solution backupservice show 00000000-0000-0000-0000-000000000000",
+		Example: "ans draas solution backupservice show 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")
@@ -61,7 +61,7 @@ func draasSolutionBackupServiceResetCredentialsCmd(f factory.ClientFactory) *cob
 		Use:     "resetcredentials <solution: id>",
 		Short:   "Resets the backup service credentials for a solution",
 		Long:    "This command resets the backup service credentials for a solution",
-		Example: "ukfast draas solution backupservice resetcredentials 00000000-0000-0000-0000-000000000000",
+		Example: "ans draas solution backupservice resetcredentials 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/draas/draas_solution_computeresource.go
+++ b/cmd/draas/draas_solution_computeresource.go
@@ -29,7 +29,7 @@ func draasSolutionComputeResourceListCmd(f factory.ClientFactory) *cobra.Command
 		Use:     "list <solution: id>",
 		Short:   "Lists solution compute resources",
 		Long:    "This command lists solution compute resource",
-		Example: "ukfast draas solution computeresource list 00000000-0000-0000-0000-000000000000",
+		Example: "ans draas solution computeresource list 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")
@@ -67,7 +67,7 @@ func draasSolutionComputeResourceShowCmd(f factory.ClientFactory) *cobra.Command
 		Use:     "show <solution: id> <computeresource: id>...",
 		Short:   "Shows solution compute resources",
 		Long:    "This command shows a solution compute resource",
-		Example: "ukfast draas solution computeresource show 00000000-0000-0000-0000-000000000000 00000000-0000-0000-0000-000000000001",
+		Example: "ans draas solution computeresource show 00000000-0000-0000-0000-000000000000 00000000-0000-0000-0000-000000000001",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/draas/draas_solution_failoverplan.go
+++ b/cmd/draas/draas_solution_failoverplan.go
@@ -32,7 +32,7 @@ func draasSolutionFailoverPlanListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <solution: id>",
 		Short:   "Lists solution failover plans",
 		Long:    "This command lists solution failover plan",
-		Example: "ukfast draas solution failoverplan list 00000000-0000-0000-0000-000000000000",
+		Example: "ans draas solution failoverplan list 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")
@@ -70,7 +70,7 @@ func draasSolutionFailoverPlanShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <solution: id> <failoverplan: id>...",
 		Short:   "Shows solution failover plans",
 		Long:    "This command shows a solution failover plan",
-		Example: "ukfast draas solution failoverplan show 00000000-0000-0000-0000-000000000000 00000000-0000-0000-0000-000000000001",
+		Example: "ans draas solution failoverplan show 00000000-0000-0000-0000-000000000000 00000000-0000-0000-0000-000000000001",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")
@@ -113,7 +113,7 @@ func draasSolutionFailoverPlanStartCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "start <solution: id> <failoverplan: id>...",
 		Short:   "Starts solution failover plan",
 		Long:    "This command starts one or more solution failover plans",
-		Example: "ukfast draas solution failoverplan start 00000000-0000-0000-0000-000000000000 00000000-0000-0000-0000-000000000001",
+		Example: "ans draas solution failoverplan start 00000000-0000-0000-0000-000000000000 00000000-0000-0000-0000-000000000001",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")
@@ -162,7 +162,7 @@ func draasSolutionFailoverPlanStopCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "stop <solution: id> <failoverplan: id>...",
 		Short:   "Stops solution failover plan",
 		Long:    "This command stops one or more solution failover plans",
-		Example: "ukfast draas solution failoverplan stop 00000000-0000-0000-0000-000000000000 00000000-0000-0000-0000-000000000001",
+		Example: "ans draas solution failoverplan stop 00000000-0000-0000-0000-000000000000 00000000-0000-0000-0000-000000000001",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/draas/draas_solution_hardwareplan.go
+++ b/cmd/draas/draas_solution_hardwareplan.go
@@ -32,7 +32,7 @@ func draasSolutionHardwarePlanListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <solution: id>",
 		Short:   "Lists solution hardware plans",
 		Long:    "This command lists solution hardware plan",
-		Example: "ukfast draas solution hardwareplan list 00000000-0000-0000-0000-000000000000",
+		Example: "ans draas solution hardwareplan list 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")
@@ -70,7 +70,7 @@ func draasSolutionHardwarePlanShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <solution: id> <hardwareplan: id>...",
 		Short:   "Shows solution hardware plans",
 		Long:    "This command shows one or more solution hardware plans",
-		Example: "ukfast draas solution hardwareplan show 00000000-0000-0000-0000-000000000000 00000000-0000-0000-0000-000000000001",
+		Example: "ans draas solution hardwareplan show 00000000-0000-0000-0000-000000000000 00000000-0000-0000-0000-000000000001",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/draas/draas_solution_hardwareplan_replica.go
+++ b/cmd/draas/draas_solution_hardwareplan_replica.go
@@ -28,7 +28,7 @@ func draasSolutionHardwarePlanReplicaListCmd(f factory.ClientFactory) *cobra.Com
 		Use:     "list <solution: id> <hardwareplan: id>",
 		Short:   "Lists solution harware plan replicas",
 		Long:    "This command lists solution harware plan replicas",
-		Example: "ukfast draas solution hardwareplan replica list 00000000-0000-0000-0000-000000000000 00000000-0000-0000-0000-000000000001",
+		Example: "ans draas solution hardwareplan replica list 00000000-0000-0000-0000-000000000000 00000000-0000-0000-0000-000000000001",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/draas/draas_solution_replica_iops.go
+++ b/cmd/draas/draas_solution_replica_iops.go
@@ -25,7 +25,7 @@ func draasSolutionReplicaIOPSUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <solution: id> <replica: id>...",
 		Short:   "Updates the IOPS for a replica",
 		Long:    "This command updates the IOPS for one or more replicas",
-		Example: "ukfast draas solution update 00000000-0000-0000-0000-000000000000 --name test",
+		Example: "ans draas solution update 00000000-0000-0000-0000-000000000000 --name test",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/ecloud/ecloud_appliance.go
+++ b/cmd/ecloud/ecloud_appliance.go
@@ -32,7 +32,7 @@ func ecloudApplianceListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists appliances",
 		Long:    "This command lists appliances",
-		Example: "ukfast ecloud appliance list",
+		Example: "ans ecloud appliance list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -63,7 +63,7 @@ func ecloudApplianceShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <appliance: id>...",
 		Short:   "Shows a appliance",
 		Long:    "This command shows one or more appliances",
-		Example: "ukfast ecloud vm appliance 00000000-0000-0000-0000-000000000000",
+		Example: "ans ecloud vm appliance 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing appliance")

--- a/cmd/ecloud/ecloud_appliance_parameter.go
+++ b/cmd/ecloud/ecloud_appliance_parameter.go
@@ -28,7 +28,7 @@ func ecloudApplianceParameterListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists appliance parameters",
 		Long:    "This command lists appliance parameters",
-		Example: "ukfast ecloud appliance parameter list 00000000-0000-0000-0000-000000000000",
+		Example: "ans ecloud appliance parameter list 00000000-0000-0000-0000-000000000000",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing appliance")

--- a/cmd/ecloud/ecloud_availabilityzone.go
+++ b/cmd/ecloud/ecloud_availabilityzone.go
@@ -32,7 +32,7 @@ func ecloudAvailabilityZoneListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists availability zones",
 		Long:    "This command lists availability zones",
-		Example: "ukfast ecloud availabilityzone list",
+		Example: "ans ecloud availabilityzone list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudAvailabilityZoneList),
 	}
 
@@ -64,7 +64,7 @@ func ecloudAvailabilityZoneShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <zone: id>...",
 		Short:   "Shows an availability zone",
 		Long:    "This command shows one or more availability zones",
-		Example: "ukfast ecloud availabilityzone show az-abcdef12",
+		Example: "ans ecloud availabilityzone show az-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing availability zone")

--- a/cmd/ecloud/ecloud_dhcp.go
+++ b/cmd/ecloud/ecloud_dhcp.go
@@ -29,7 +29,7 @@ func ecloudDHCPListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists DHCPs",
 		Long:    "This command lists DHCPs",
-		Example: "ukfast ecloud dhcp list",
+		Example: "ans ecloud dhcp list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudDHCPList),
 	}
 
@@ -61,7 +61,7 @@ func ecloudDHCPShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <dhcp: id>...",
 		Short:   "Shows a DHCP",
 		Long:    "This command shows one or more DHCPs",
-		Example: "ukfast ecloud dhcp show dhcp-abcdef12",
+		Example: "ans ecloud dhcp show dhcp-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing dhcp")

--- a/cmd/ecloud/ecloud_firewallpolicy.go
+++ b/cmd/ecloud/ecloud_firewallpolicy.go
@@ -36,7 +36,7 @@ func ecloudFirewallPolicyListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists firewall policies",
 		Long:    "This command lists firewall policies",
-		Example: "ukfast ecloud firewallpolicy list",
+		Example: "ans ecloud firewallpolicy list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudFirewallPolicyList),
 	}
 
@@ -68,7 +68,7 @@ func ecloudFirewallPolicyShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <policy: id>...",
 		Short:   "Shows a firewall policy",
 		Long:    "This command shows one or more firewall policies",
-		Example: "ukfast ecloud firewallpolicy show fwp-abcdef12",
+		Example: "ans ecloud firewallpolicy show fwp-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing firewall policy")
@@ -100,7 +100,7 @@ func ecloudFirewallPolicyCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a firewall policy",
 		Long:    "This command creates a firewall policy",
-		Example: "ukfast ecloud firewallpolicy create --router rtr-abcdef12",
+		Example: "ans ecloud firewallpolicy create --router rtr-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudFirewallPolicyCreate),
 	}
 
@@ -151,7 +151,7 @@ func ecloudFirewallPolicyUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <policy: id>...",
 		Short:   "Updates a firewall policy",
 		Long:    "This command updates one or more firewall policies",
-		Example: "ukfast ecloud firewallpolicy update fwp-abcdef12 --name \"my policy\"",
+		Example: "ans ecloud firewallpolicy update fwp-abcdef12 --name \"my policy\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing firewall policy")
@@ -209,7 +209,7 @@ func ecloudFirewallPolicyDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <policy: id>...",
 		Short:   "Removes a firewall policy",
 		Long:    "This command removes one or more firewall policies",
-		Example: "ukfast ecloud firewallpolicy delete fwp-abcdef12",
+		Example: "ans ecloud firewallpolicy delete fwp-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing firewall policy")

--- a/cmd/ecloud/ecloud_firewallpolicy_rule.go
+++ b/cmd/ecloud/ecloud_firewallpolicy_rule.go
@@ -28,7 +28,7 @@ func ecloudFirewallPolicyFirewallRuleListCmd(f factory.ClientFactory) *cobra.Com
 		Use:     "list",
 		Short:   "Lists firewall rules for firewall policy",
 		Long:    "This command lists firewall rules for firewall policy",
-		Example: "ukfast ecloud firewallpolicy firewallrule list fwp-abcdef12",
+		Example: "ans ecloud firewallpolicy firewallrule list fwp-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing firewall policy")

--- a/cmd/ecloud/ecloud_firewallpolicy_task.go
+++ b/cmd/ecloud/ecloud_firewallpolicy_task.go
@@ -28,7 +28,7 @@ func ecloudFirewallPolicyTaskListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <policy: id>",
 		Short:   "Lists firewall policy tasks",
 		Long:    "This command lists firewall policy tasks",
-		Example: "ukfast ecloud firewall policy task list i-abcdef12",
+		Example: "ans ecloud firewall policy task list i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing firewall policy")

--- a/cmd/ecloud/ecloud_firewallrule.go
+++ b/cmd/ecloud/ecloud_firewallrule.go
@@ -36,7 +36,7 @@ func ecloudFirewallRuleListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists firewall rules",
 		Long:    "This command lists firewall rules",
-		Example: "ukfast ecloud firewallrule list",
+		Example: "ans ecloud firewallrule list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudFirewallRuleList),
 	}
 
@@ -67,7 +67,7 @@ func ecloudFirewallRuleShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <rule: id>...",
 		Short:   "Shows an firewall rule",
 		Long:    "This command shows one or more firewall rules",
-		Example: "ukfast ecloud firewallrule show fwr-abcdef12",
+		Example: "ans ecloud firewallrule show fwr-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing firewall rule")
@@ -99,7 +99,7 @@ func ecloudFirewallRuleCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a firewall rule",
 		Long:    "This command creates a firewall rule",
-		Example: "ukfast ecloud firewallrule create --policy fwp-abcdef12",
+		Example: "ans ecloud firewallrule create --policy fwp-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudFirewallRuleCreate),
 	}
 
@@ -176,7 +176,7 @@ func ecloudFirewallRuleUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <rule: id>...",
 		Short:   "Updates a firewall rule",
 		Long:    "This command updates one or more firewall rules",
-		Example: "ukfast ecloud firewallrule update fwp-abcdef12 --name \"my rule\"",
+		Example: "ans ecloud firewallrule update fwp-abcdef12 --name \"my rule\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing firewall rule")
@@ -277,7 +277,7 @@ func ecloudFirewallRuleDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <rule: id>...",
 		Short:   "Removes a firewall rule",
 		Long:    "This command removes one or more firewall rules",
-		Example: "ukfast ecloud firewallrule delete fwr-abcdef12",
+		Example: "ans ecloud firewallrule delete fwr-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing firewall rule")

--- a/cmd/ecloud/ecloud_firewallrule_port.go
+++ b/cmd/ecloud/ecloud_firewallrule_port.go
@@ -28,7 +28,7 @@ func ecloudFirewallRuleFirewallRulePortListCmd(f factory.ClientFactory) *cobra.C
 		Use:     "list",
 		Short:   "Lists ports for firewall rule",
 		Long:    "This command lists ports for firewall rule",
-		Example: "ukfast ecloud firewallrule firewallport list fwp-abcdef12",
+		Example: "ans ecloud firewallrule firewallport list fwp-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing firewall rule")

--- a/cmd/ecloud/ecloud_firewallruleport.go
+++ b/cmd/ecloud/ecloud_firewallruleport.go
@@ -32,7 +32,7 @@ func ecloudFirewallRulePortListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists firewall rule ports",
 		Long:    "This command lists firewall rule ports",
-		Example: "ukfast ecloud firewallruleport list",
+		Example: "ans ecloud firewallruleport list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudFirewallRulePortList),
 	}
 
@@ -63,7 +63,7 @@ func ecloudFirewallRulePortShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <port: id>...",
 		Short:   "Shows a firewall rule port",
 		Long:    "This command shows one or more firewall rule ports",
-		Example: "ukfast ecloud firewallruleport show fwrp-abcdef12",
+		Example: "ans ecloud firewallruleport show fwrp-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing firewall rule port")
@@ -95,7 +95,7 @@ func ecloudFirewallRulePortCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a firewall rule port",
 		Long:    "This command creates a firewall rule port",
-		Example: "ukfast ecloud firewallruleport create --rule fwr-abcdef12",
+		Example: "ans ecloud firewallruleport create --rule fwr-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudFirewallRulePortCreate),
 	}
 
@@ -155,7 +155,7 @@ func ecloudFirewallRulePortUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <port: id>...",
 		Short:   "Updates a firewall rule port",
 		Long:    "This command updates one or more firewall rule ports",
-		Example: "ukfast ecloud firewallruleport update fwrp-abcdef12 --name \"my port\"",
+		Example: "ans ecloud firewallruleport update fwrp-abcdef12 --name \"my port\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing firewall rule port")
@@ -234,7 +234,7 @@ func ecloudFirewallRulePortDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <port: id>...",
 		Short:   "Removes a firewall rule port",
 		Long:    "This command removes one or more firewall rule ports",
-		Example: "ukfast ecloud firewallruleport delete fwrp-abcdef12",
+		Example: "ans ecloud firewallruleport delete fwrp-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing firewall rule port")

--- a/cmd/ecloud/ecloud_floatingip.go
+++ b/cmd/ecloud/ecloud_floatingip.go
@@ -34,7 +34,7 @@ func ecloudFloatingIPListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists floating IPs",
 		Long:    "This command lists floating IPs",
-		Example: "ukfast ecloud floatingip list",
+		Example: "ans ecloud floatingip list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudFloatingIPList),
 	}
 }
@@ -58,7 +58,7 @@ func ecloudFloatingIPShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <floatingip: id>...",
 		Short:   "Shows a floating IP",
 		Long:    "This command shows one or more floating IPs",
-		Example: "ukfast ecloud floatingip show fip-abcdef12",
+		Example: "ans ecloud floatingip show fip-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing floating IP")
@@ -90,7 +90,7 @@ func ecloudFloatingIPCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a floating IP",
 		Long:    "This command creates a floating IP address",
-		Example: "ukfast ecloud floatingip create --vpc vpc-abcdef12 --availability-zone az-abcdef12",
+		Example: "ans ecloud floatingip create --vpc vpc-abcdef12 --availability-zone az-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudFloatingIPCreate),
 	}
 
@@ -139,7 +139,7 @@ func ecloudFloatingIPUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <fip: id>...",
 		Short:   "Updates a floating IP",
 		Long:    "This command updates one or more floating IPs",
-		Example: "ukfast ecloud floatingip update fip-abcdef12 --name \"my fip\"",
+		Example: "ans ecloud floatingip update fip-abcdef12 --name \"my fip\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing floating IP")
@@ -197,7 +197,7 @@ func ecloudFloatingIPDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <fip: id>...",
 		Short:   "Removes a floating IP",
 		Long:    "This command removes one or more floating IPs",
-		Example: "ukfast ecloud floatingip delete fip-abcdef12",
+		Example: "ans ecloud floatingip delete fip-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing floating IP")
@@ -238,7 +238,7 @@ func ecloudFloatingIPAssignCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "assign <fip: id>",
 		Short:   "Assigns a floating IP to a resource",
 		Long:    "This command assigns a floating IP to a resource",
-		Example: "ukfast ecloud floatingip assign fip-abcdef12 --resource i-abcdef12",
+		Example: "ans ecloud floatingip assign fip-abcdef12 --resource i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing floating IP")
@@ -289,7 +289,7 @@ func ecloudFloatingIPUnassignCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "unassign <fip: id>...",
 		Short:   "Unassigns a floating IP",
 		Long:    "This command unassigns one or more floating IPs from connected resources",
-		Example: "ukfast ecloud floatingip unassign fip-abcdef12",
+		Example: "ans ecloud floatingip unassign fip-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing floating IP")

--- a/cmd/ecloud/ecloud_host.go
+++ b/cmd/ecloud/ecloud_host.go
@@ -32,7 +32,7 @@ func ecloudHostListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists hosts",
 		Long:    "This command lists hosts",
-		Example: "ukfast ecloud host list",
+		Example: "ans ecloud host list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudHostList),
 	}
 
@@ -62,7 +62,7 @@ func ecloudHostShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <group: id>...",
 		Short:   "Shows an host",
 		Long:    "This command shows one or more hosts",
-		Example: "ukfast ecloud host show h-abcdef12",
+		Example: "ans ecloud host show h-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing host")
@@ -94,7 +94,7 @@ func ecloudHostCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a host",
 		Long:    "This command creates a host",
-		Example: "ukfast ecloud host create --policy np-abcdef12",
+		Example: "ans ecloud host create --policy np-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudHostCreate),
 	}
 
@@ -138,7 +138,7 @@ func ecloudHostUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <group: id>...",
 		Short:   "Updates a host",
 		Long:    "This command updates one or more hosts",
-		Example: "ukfast ecloud host update np-abcdef12 --name \"my group\"",
+		Example: "ans ecloud host update np-abcdef12 --name \"my group\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing host")
@@ -196,7 +196,7 @@ func ecloudHostDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <group: id>...",
 		Short:   "Removes a host",
 		Long:    "This command removes one or more hosts",
-		Example: "ukfast ecloud host delete h-abcdef12",
+		Example: "ans ecloud host delete h-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing host")

--- a/cmd/ecloud/ecloud_hostgroup.go
+++ b/cmd/ecloud/ecloud_hostgroup.go
@@ -32,7 +32,7 @@ func ecloudHostGroupListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists host groups",
 		Long:    "This command lists host groups",
-		Example: "ukfast ecloud hostgroup list",
+		Example: "ans ecloud hostgroup list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudHostGroupList),
 	}
 
@@ -62,7 +62,7 @@ func ecloudHostGroupShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <group: id>...",
 		Short:   "Shows an host group",
 		Long:    "This command shows one or more host groups",
-		Example: "ukfast ecloud hostgroup show hg-abcdef12",
+		Example: "ans ecloud hostgroup show hg-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing host group")
@@ -94,7 +94,7 @@ func ecloudHostGroupCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a host group",
 		Long:    "This command creates a host group",
-		Example: "ukfast ecloud hostgroup create --policy hg-abcdef12",
+		Example: "ans ecloud hostgroup create --policy hg-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudHostGroupCreate),
 	}
 
@@ -145,7 +145,7 @@ func ecloudHostGroupUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <group: id>...",
 		Short:   "Updates a host group",
 		Long:    "This command updates one or more host groups",
-		Example: "ukfast ecloud hostgroup update hg-abcdef12 --name \"my group\"",
+		Example: "ans ecloud hostgroup update hg-abcdef12 --name \"my group\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing host group")
@@ -203,7 +203,7 @@ func ecloudHostGroupDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <group: id>...",
 		Short:   "Removes a host group",
 		Long:    "This command removes one or more host groups",
-		Example: "ukfast ecloud hostgroup delete hg-abcdef12",
+		Example: "ans ecloud hostgroup delete hg-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing host group")

--- a/cmd/ecloud/ecloud_hostspec.go
+++ b/cmd/ecloud/ecloud_hostspec.go
@@ -29,7 +29,7 @@ func ecloudHostSpecListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists host specs",
 		Long:    "This command lists host specs",
-		Example: "ukfast ecloud hostspec list",
+		Example: "ans ecloud hostspec list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudHostSpecList),
 	}
 
@@ -59,7 +59,7 @@ func ecloudHostSpecShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <spec: id>...",
 		Short:   "Shows an host spec",
 		Long:    "This command shows one or more host specs",
-		Example: "ukfast ecloud hostspec show hs-abcdef12",
+		Example: "ans ecloud hostspec show hs-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing host spec")

--- a/cmd/ecloud/ecloud_image.go
+++ b/cmd/ecloud/ecloud_image.go
@@ -33,7 +33,7 @@ func ecloudImageListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists images",
 		Long:    "This command lists images",
-		Example: "ukfast ecloud image list",
+		Example: "ans ecloud image list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudImageList),
 	}
 }
@@ -57,7 +57,7 @@ func ecloudImageShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <image: id>...",
 		Short:   "Shows a image",
 		Long:    "This command shows one or more images",
-		Example: "ukfast ecloud vm image img-abcdef12",
+		Example: "ans ecloud vm image img-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing image")

--- a/cmd/ecloud/ecloud_image_metadata.go
+++ b/cmd/ecloud/ecloud_image_metadata.go
@@ -28,7 +28,7 @@ func ecloudImageMetadataListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists image metadata",
 		Long:    "This command lists image metadata",
-		Example: "ukfast ecloud image metadata list img-abcdef12",
+		Example: "ans ecloud image metadata list img-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing image")

--- a/cmd/ecloud/ecloud_image_parameter.go
+++ b/cmd/ecloud/ecloud_image_parameter.go
@@ -28,7 +28,7 @@ func ecloudImageParameterListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists image parameters",
 		Long:    "This command lists image parameters",
-		Example: "ukfast ecloud image parameter list img-abcdef12",
+		Example: "ans ecloud image parameter list img-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing image")

--- a/cmd/ecloud/ecloud_instance.go
+++ b/cmd/ecloud/ecloud_instance.go
@@ -52,7 +52,7 @@ func ecloudInstanceListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists instances",
 		Long:    "This command lists instances",
-		Example: "ukfast ecloud instance list",
+		Example: "ans ecloud instance list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudInstanceList),
 	}
 
@@ -80,7 +80,7 @@ func ecloudInstanceShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <instance: id>...",
 		Short:   "Shows a instance",
 		Long:    "This command shows one or more instances",
-		Example: "ukfast ecloud instance show i-abcdef12",
+		Example: "ans ecloud instance show i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")
@@ -112,7 +112,7 @@ func ecloudInstanceCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates an instance",
 		Long:    "This command creates an instance",
-		Example: "ukfast ecloud instance create --vpc vpc-abcdef12 --vcpu 2 --ram 2048 --volume 20 --image \"CentOS 7\"",
+		Example: "ans ecloud instance create --vpc vpc-abcdef12 --vcpu 2 --ram 2048 --volume 20 --image \"CentOS 7\"",
 		RunE:    ecloudCobraRunEFunc(f, ecloudInstanceCreate),
 	}
 
@@ -209,7 +209,7 @@ func ecloudInstanceUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <instance: id>...",
 		Short:   "Updates an instance",
 		Long:    "This command updates one or more instances",
-		Example: "ukfast ecloud instance update i-abcdef12 --name \"my instance\"",
+		Example: "ans ecloud instance update i-abcdef12 --name \"my instance\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")
@@ -285,7 +285,7 @@ func ecloudInstanceDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <instance: id>...",
 		Short:   "Removes an instance",
 		Long:    "This command removes one or more instances",
-		Example: "ukfast ecloud instance delete i-abcdef12",
+		Example: "ans ecloud instance delete i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")
@@ -326,7 +326,7 @@ func ecloudInstanceLockCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "lock <instance: id>...",
 		Short:   "Locks an instance",
 		Long:    "This command locks one or more instances",
-		Example: "ukfast ecloud instance lock i-abcdef12",
+		Example: "ans ecloud instance lock i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")
@@ -353,7 +353,7 @@ func ecloudInstanceUnlockCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "unlock <instance: id>...",
 		Short:   "Unlocks an instance",
 		Long:    "This command unlocks one or more instances",
-		Example: "ukfast ecloud instance unlock i-abcdef12",
+		Example: "ans ecloud instance unlock i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")
@@ -380,7 +380,7 @@ func ecloudInstanceStartCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "start <instance: id>...",
 		Short:   "Starts an instance",
 		Long:    "This command powers on one or more instances",
-		Example: "ukfast ecloud instance start i-abcdef12",
+		Example: "ans ecloud instance start i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")
@@ -421,7 +421,7 @@ func ecloudInstanceStopCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "stop <instance: id>...",
 		Short:   "Stops an instance",
 		Long:    "This command powers off one or more instances",
-		Example: "ukfast ecloud instance stop i-abcdef12",
+		Example: "ans ecloud instance stop i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")
@@ -475,7 +475,7 @@ func ecloudInstanceRestartCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "restart <instance: id>...",
 		Short:   "Restarts an instance",
 		Long:    "This command restarts one or more instances",
-		Example: "ukfast ecloud instance restart i-abcdef12",
+		Example: "ans ecloud instance restart i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")
@@ -529,7 +529,7 @@ func ecloudInstanceSSHCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "ssh <instance: id>",
 		Short:   "Invokes SSH for an instance",
 		Long:    "This command invokes SSH for an instance",
-		Example: "ukfast ecloud instance ssh i-abcdef12",
+		Example: "ans ecloud instance ssh i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")

--- a/cmd/ecloud/ecloud_instance_consolesession.go
+++ b/cmd/ecloud/ecloud_instance_consolesession.go
@@ -28,7 +28,7 @@ func ecloudInstanceConsoleSessionCreateCmd(f factory.ClientFactory) *cobra.Comma
 		Use:     "create <instance: id>",
 		Short:   "Creates an instance console session",
 		Long:    "This command creates one or more instance console sessions",
-		Example: "ukfast ecloud instance consolesession create i-abcdef12",
+		Example: "ans ecloud instance consolesession create i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")

--- a/cmd/ecloud/ecloud_instance_credential.go
+++ b/cmd/ecloud/ecloud_instance_credential.go
@@ -28,7 +28,7 @@ func ecloudInstanceCredentialListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists instance credentials",
 		Long:    "This command lists instance credentials",
-		Example: "ukfast ecloud instance credential list i-abcdef12",
+		Example: "ans ecloud instance credential list i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")

--- a/cmd/ecloud/ecloud_instance_floatingip.go
+++ b/cmd/ecloud/ecloud_instance_floatingip.go
@@ -28,7 +28,7 @@ func ecloudInstanceFloatingIPListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists instance floating IPs",
 		Long:    "This command lists instance floating IPs",
-		Example: "ukfast ecloud instance floatingip list i-abcdef12",
+		Example: "ans ecloud instance floatingip list i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")

--- a/cmd/ecloud/ecloud_instance_nic.go
+++ b/cmd/ecloud/ecloud_instance_nic.go
@@ -28,7 +28,7 @@ func ecloudInstanceNICListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists instance nics",
 		Long:    "This command lists instance nics",
-		Example: "ukfast ecloud instance nic list i-abcdef12",
+		Example: "ans ecloud instance nic list i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")

--- a/cmd/ecloud/ecloud_instance_task.go
+++ b/cmd/ecloud/ecloud_instance_task.go
@@ -28,7 +28,7 @@ func ecloudInstanceTaskListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <instance: id>",
 		Short:   "Lists instance tasks",
 		Long:    "This command lists instance tasks",
-		Example: "ukfast ecloud instance task list i-abcdef12",
+		Example: "ans ecloud instance task list i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")

--- a/cmd/ecloud/ecloud_instance_volume.go
+++ b/cmd/ecloud/ecloud_instance_volume.go
@@ -30,7 +30,7 @@ func ecloudInstanceVolumeListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists instance volumes",
 		Long:    "This command lists instance volumes",
-		Example: "ukfast ecloud instance volume list i-abcdef12",
+		Example: "ans ecloud instance volume list i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")
@@ -65,7 +65,7 @@ func ecloudInstanceVolumeAttachCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "attach",
 		Short:   "Attaches a volume to an instances",
 		Long:    "This command attaches a volume to an instance",
-		Example: "ukfast ecloud instance volume attach i-abcdef12 --volume vol-abcdef12",
+		Example: "ans ecloud instance volume attach i-abcdef12 --volume vol-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")
@@ -108,7 +108,7 @@ func ecloudInstanceVolumeDetachCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "detach",
 		Short:   "Detaches a volume from an instance",
 		Long:    "This command detaches a volume from an instance",
-		Example: "ukfast ecloud instance volume detach i-abcdef12 --volume vol-abcdef12",
+		Example: "ans ecloud instance volume detach i-abcdef12 --volume vol-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing instance")

--- a/cmd/ecloud/ecloud_ipaddress.go
+++ b/cmd/ecloud/ecloud_ipaddress.go
@@ -33,7 +33,7 @@ func ecloudIPAddressListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists IP addresses",
 		Long:    "This command lists IP addresses",
-		Example: "ukfast ecloud ipaddress list",
+		Example: "ans ecloud ipaddress list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudIPAddressList),
 	}
 
@@ -63,7 +63,7 @@ func ecloudIPAddressShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <ip: id>...",
 		Short:   "Shows a IP address",
 		Long:    "This command shows one or more IP addresses",
-		Example: "ukfast ecloud ipaddress show ip-abcdef12",
+		Example: "ans ecloud ipaddress show ip-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing IP address")
@@ -95,7 +95,7 @@ func ecloudIPAddressCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a IP address",
 		Long:    "This command creates a IP address",
-		Example: "ukfast ecloud ipaddress create --network net-abcdef12",
+		Example: "ans ecloud ipaddress create --network net-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudIPAddressCreate),
 	}
 
@@ -142,7 +142,7 @@ func ecloudIPAddressUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <ip: id>...",
 		Short:   "Updates a IP address",
 		Long:    "This command updates one or more IP addresses",
-		Example: "ukfast ecloud ipaddress update ip-abcdef12 --name \"my ip\"",
+		Example: "ans ecloud ipaddress update ip-abcdef12 --name \"my ip\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing IP address")
@@ -197,7 +197,7 @@ func ecloudIPAddressDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <ip: id>...",
 		Short:   "Removes a IP address",
 		Long:    "This command removes one or more IP addresses",
-		Example: "ukfast ecloud ipaddress delete ip-abcdef12",
+		Example: "ans ecloud ipaddress delete ip-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing IP address")

--- a/cmd/ecloud/ecloud_loadbalancer.go
+++ b/cmd/ecloud/ecloud_loadbalancer.go
@@ -32,7 +32,7 @@ func ecloudLoadBalancerListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists load balancers",
 		Long:    "This command lists load balancers",
-		Example: "ukfast ecloud loadbalancer list",
+		Example: "ans ecloud loadbalancer list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudLoadBalancerList),
 	}
 
@@ -64,7 +64,7 @@ func ecloudLoadBalancerShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <lb: id>...",
 		Short:   "Shows an load balancer",
 		Long:    "This command shows one or more load balancers",
-		Example: "ukfast ecloud loadbalancer show lb-abcdef12",
+		Example: "ans ecloud loadbalancer show lb-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing load balancer")
@@ -96,7 +96,7 @@ func ecloudLoadBalancerCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a load balancer",
 		Long:    "This command creates a load balancer",
-		Example: "ukfast ecloud loadbalancer create --vpc vpc-abcdef12 --availability-zone az-abcdef12 --spec lbs-abcdef12",
+		Example: "ans ecloud loadbalancer create --vpc vpc-abcdef12 --availability-zone az-abcdef12 --spec lbs-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudLoadBalancerCreate),
 	}
 
@@ -149,7 +149,7 @@ func ecloudLoadBalancerUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <lb: id>...",
 		Short:   "Updates a load balancer",
 		Long:    "This command updates one or more load balancers",
-		Example: "ukfast ecloud loadbalancer update lb-abcdef12 --name \"my lb\"",
+		Example: "ans ecloud loadbalancer update lb-abcdef12 --name \"my lb\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing load balancer")
@@ -207,7 +207,7 @@ func ecloudLoadBalancerDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <lb: id>...",
 		Short:   "Removes a load balancer",
 		Long:    "This command removes one or more load balancers",
-		Example: "ukfast ecloud loadbalancer delete lb-abcdef12",
+		Example: "ans ecloud loadbalancer delete lb-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing load balancer")

--- a/cmd/ecloud/ecloud_loadbalancerspec.go
+++ b/cmd/ecloud/ecloud_loadbalancerspec.go
@@ -29,7 +29,7 @@ func ecloudLoadBalancerSpecListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists load balancer specs",
 		Long:    "This command lists load balancer specs",
-		Example: "ukfast ecloud loadbalancer list",
+		Example: "ans ecloud loadbalancer list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudLoadBalancerSpecList),
 	}
 
@@ -59,7 +59,7 @@ func ecloudLoadBalancerSpecShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <spec: id>...",
 		Short:   "Shows an load balancer spec",
 		Long:    "This command shows one or more load balancer specs",
-		Example: "ukfast ecloud loadbalancerspec show lbn-abcdef12",
+		Example: "ans ecloud loadbalancerspec show lbn-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing load balancer spec")

--- a/cmd/ecloud/ecloud_network.go
+++ b/cmd/ecloud/ecloud_network.go
@@ -35,7 +35,7 @@ func ecloudNetworkListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists networks",
 		Long:    "This command lists networks",
-		Example: "ukfast ecloud network list",
+		Example: "ans ecloud network list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudNetworkList),
 	}
 
@@ -67,7 +67,7 @@ func ecloudNetworkShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <network: id>...",
 		Short:   "Shows a network",
 		Long:    "This command shows one or more networks",
-		Example: "ukfast ecloud network show net-abcdef12",
+		Example: "ans ecloud network show net-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network")
@@ -99,7 +99,7 @@ func ecloudNetworkCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates an network",
 		Long:    "This command creates an network",
-		Example: "ukfast ecloud network create --router rtr-abcdef12",
+		Example: "ans ecloud network create --router rtr-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudNetworkCreate),
 	}
 
@@ -148,7 +148,7 @@ func ecloudNetworkUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <network: id>...",
 		Short:   "Updates an network",
 		Long:    "This command updates one or more networks",
-		Example: "ukfast ecloud network update net-abcdef12 --name \"my network\"",
+		Example: "ans ecloud network update net-abcdef12 --name \"my network\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network")
@@ -206,7 +206,7 @@ func ecloudNetworkDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <network: id>...",
 		Short:   "Removes an network",
 		Long:    "This command removes one or more networks",
-		Example: "ukfast ecloud network delete net-abcdef12",
+		Example: "ans ecloud network delete net-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network")

--- a/cmd/ecloud/ecloud_network_nic.go
+++ b/cmd/ecloud/ecloud_network_nic.go
@@ -28,7 +28,7 @@ func ecloudNetworkNICListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists network nics",
 		Long:    "This command lists network nics",
-		Example: "ukfast ecloud network nic list net-abcdef12",
+		Example: "ans ecloud network nic list net-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network")

--- a/cmd/ecloud/ecloud_network_task.go
+++ b/cmd/ecloud/ecloud_network_task.go
@@ -28,7 +28,7 @@ func ecloudNetworkTaskListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <network: id>",
 		Short:   "Lists network tasks",
 		Long:    "This command lists network tasks",
-		Example: "ukfast ecloud network task list net-abcdef12",
+		Example: "ans ecloud network task list net-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network")

--- a/cmd/ecloud/ecloud_networkpolicy.go
+++ b/cmd/ecloud/ecloud_networkpolicy.go
@@ -36,7 +36,7 @@ func ecloudNetworkPolicyListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists network policies",
 		Long:    "This command lists network policies",
-		Example: "ukfast ecloud networkpolicy list",
+		Example: "ans ecloud networkpolicy list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudNetworkPolicyList),
 	}
 
@@ -68,7 +68,7 @@ func ecloudNetworkPolicyShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <policy: id>...",
 		Short:   "Shows a network policy",
 		Long:    "This command shows one or more network policies",
-		Example: "ukfast ecloud networkpolicy show np-abcdef12",
+		Example: "ans ecloud networkpolicy show np-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network policy")
@@ -100,7 +100,7 @@ func ecloudNetworkPolicyCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a network policy",
 		Long:    "This command creates a network policy",
-		Example: "ukfast ecloud networkpolicy create --network rtr-abcdef12",
+		Example: "ans ecloud networkpolicy create --network rtr-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudNetworkPolicyCreate),
 	}
 
@@ -155,7 +155,7 @@ func ecloudNetworkPolicyUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <policy: id>...",
 		Short:   "Updates a network policy",
 		Long:    "This command updates one or more network policies",
-		Example: "ukfast ecloud networkpolicy update np-abcdef12 --name \"my policy\"",
+		Example: "ans ecloud networkpolicy update np-abcdef12 --name \"my policy\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network policy")
@@ -222,7 +222,7 @@ func ecloudNetworkPolicyDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <policy: id>...",
 		Short:   "Removes a network policy",
 		Long:    "This command removes one or more network policies",
-		Example: "ukfast ecloud networkpolicy delete np-abcdef12",
+		Example: "ans ecloud networkpolicy delete np-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network policy")

--- a/cmd/ecloud/ecloud_networkpolicy_rule.go
+++ b/cmd/ecloud/ecloud_networkpolicy_rule.go
@@ -28,7 +28,7 @@ func ecloudNetworkPolicyNetworkRuleListCmd(f factory.ClientFactory) *cobra.Comma
 		Use:     "list",
 		Short:   "Lists network rules for network policy",
 		Long:    "This command lists network rules for network policy",
-		Example: "ukfast ecloud networkpolicy networkrule list np-abcdef12",
+		Example: "ans ecloud networkpolicy networkrule list np-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network policy")

--- a/cmd/ecloud/ecloud_networkpolicy_task.go
+++ b/cmd/ecloud/ecloud_networkpolicy_task.go
@@ -28,7 +28,7 @@ func ecloudNetworkPolicyTaskListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <policy: id>",
 		Short:   "Lists network policy tasks",
 		Long:    "This command lists network policy tasks",
-		Example: "ukfast ecloud network policy task list i-abcdef12",
+		Example: "ans ecloud network policy task list i-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network policy")

--- a/cmd/ecloud/ecloud_networkrule.go
+++ b/cmd/ecloud/ecloud_networkrule.go
@@ -36,7 +36,7 @@ func ecloudNetworkRuleListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists network rules",
 		Long:    "This command lists network rules",
-		Example: "ukfast ecloud networkrule list",
+		Example: "ans ecloud networkrule list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudNetworkRuleList),
 	}
 
@@ -67,7 +67,7 @@ func ecloudNetworkRuleShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <rule: id>...",
 		Short:   "Shows an network rule",
 		Long:    "This command shows one or more network rules",
-		Example: "ukfast ecloud networkrule show nr-abcdef12",
+		Example: "ans ecloud networkrule show nr-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network rule")
@@ -99,7 +99,7 @@ func ecloudNetworkRuleCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a network rule",
 		Long:    "This command creates a network rule",
-		Example: "ukfast ecloud networkrule create --policy np-abcdef12",
+		Example: "ans ecloud networkrule create --policy np-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudNetworkRuleCreate),
 	}
 
@@ -176,7 +176,7 @@ func ecloudNetworkRuleUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <rule: id>...",
 		Short:   "Updates a network rule",
 		Long:    "This command updates one or more network rules",
-		Example: "ukfast ecloud networkrule update np-abcdef12 --name \"my rule\"",
+		Example: "ans ecloud networkrule update np-abcdef12 --name \"my rule\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network rule")
@@ -277,7 +277,7 @@ func ecloudNetworkRuleDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <rule: id>...",
 		Short:   "Removes a network rule",
 		Long:    "This command removes one or more network rules",
-		Example: "ukfast ecloud networkrule delete nr-abcdef12",
+		Example: "ans ecloud networkrule delete nr-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network rule")

--- a/cmd/ecloud/ecloud_networkrule_port.go
+++ b/cmd/ecloud/ecloud_networkrule_port.go
@@ -28,7 +28,7 @@ func ecloudNetworkRuleNetworkRulePortListCmd(f factory.ClientFactory) *cobra.Com
 		Use:     "list",
 		Short:   "Lists ports for network rule",
 		Long:    "This command lists ports for network rule",
-		Example: "ukfast ecloud networkrule networkport list np-abcdef12",
+		Example: "ans ecloud networkrule networkport list np-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network rule")

--- a/cmd/ecloud/ecloud_networkruleport.go
+++ b/cmd/ecloud/ecloud_networkruleport.go
@@ -32,7 +32,7 @@ func ecloudNetworkRulePortListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists network rule ports",
 		Long:    "This command lists network rule ports",
-		Example: "ukfast ecloud networkruleport list",
+		Example: "ans ecloud networkruleport list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudNetworkRulePortList),
 	}
 
@@ -63,7 +63,7 @@ func ecloudNetworkRulePortShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <port: id>...",
 		Short:   "Shows a network rule port",
 		Long:    "This command shows one or more network rule ports",
-		Example: "ukfast ecloud networkruleport show nrp-abcdef12",
+		Example: "ans ecloud networkruleport show nrp-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network rule port")
@@ -95,7 +95,7 @@ func ecloudNetworkRulePortCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a network rule port",
 		Long:    "This command creates a network rule port",
-		Example: "ukfast ecloud networkruleport create --rule nr-abcdef12",
+		Example: "ans ecloud networkruleport create --rule nr-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudNetworkRulePortCreate),
 	}
 
@@ -155,7 +155,7 @@ func ecloudNetworkRulePortUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <port: id>...",
 		Short:   "Updates a network rule port",
 		Long:    "This command updates one or more network rule ports",
-		Example: "ukfast ecloud networkruleport update nrp-abcdef12 --name \"my port\"",
+		Example: "ans ecloud networkruleport update nrp-abcdef12 --name \"my port\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network rule port")
@@ -234,7 +234,7 @@ func ecloudNetworkRulePortDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <port: id>...",
 		Short:   "Removes a network rule port",
 		Long:    "This command removes one or more network rule ports",
-		Example: "ukfast ecloud networkruleport delete nrp-abcdef12",
+		Example: "ans ecloud networkruleport delete nrp-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing network rule port")

--- a/cmd/ecloud/ecloud_nic.go
+++ b/cmd/ecloud/ecloud_nic.go
@@ -32,7 +32,7 @@ func ecloudNICListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists NICs",
 		Long:    "This command lists NICs",
-		Example: "ukfast ecloud nic list",
+		Example: "ans ecloud nic list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudNICList),
 	}
 
@@ -60,7 +60,7 @@ func ecloudNICShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <nic: id>...",
 		Short:   "Shows a NIC",
 		Long:    "This command shows one or more NICs",
-		Example: "ukfast ecloud nic show nic-abcdef12",
+		Example: "ans ecloud nic show nic-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing nic")

--- a/cmd/ecloud/ecloud_nic_ipaddress.go
+++ b/cmd/ecloud/ecloud_nic_ipaddress.go
@@ -30,7 +30,7 @@ func ecloudNICIPAddressListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists IP addresses for NIC",
 		Long:    "This command lists IP addresses for NIC",
-		Example: "ukfast ecloud nic ipaddress list ip-abcdef12",
+		Example: "ans ecloud nic ipaddress list ip-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing NIC")
@@ -65,7 +65,7 @@ func ecloudNICIPAddressAssignCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "assign",
 		Short:   "Assigns an IP address to a NIC",
 		Long:    "This command assigns an IP address to one or more NICs",
-		Example: "ukfast ecloud nic ipaddress assign nic-abcdef12 --ip-address ip-abcdef12",
+		Example: "ans ecloud nic ipaddress assign nic-abcdef12 --ip-address ip-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing NIC")
@@ -112,7 +112,7 @@ func ecloudNICIPAddressUnassignCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "unassign",
 		Short:   "Unassigns an IP address from a NIC",
 		Long:    "This command unassigns an IP address from one or more NICs",
-		Example: "ukfast ecloud nic ipaddress unassign nic-abcdef12 --ip-address ip-abcdef12",
+		Example: "ans ecloud nic ipaddress unassign nic-abcdef12 --ip-address ip-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing NIC")

--- a/cmd/ecloud/ecloud_region.go
+++ b/cmd/ecloud/ecloud_region.go
@@ -29,7 +29,7 @@ func ecloudRegionListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists regions",
 		Long:    "This command lists regions",
-		Example: "ukfast ecloud region list",
+		Example: "ans ecloud region list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudRegionList),
 	}
 
@@ -57,7 +57,7 @@ func ecloudRegionShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <region: id>...",
 		Short:   "Shows a region",
 		Long:    "This command shows one or more regions",
-		Example: "ukfast ecloud region show reg-abcdef12",
+		Example: "ans ecloud region show reg-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing region")

--- a/cmd/ecloud/ecloud_router.go
+++ b/cmd/ecloud/ecloud_router.go
@@ -38,7 +38,7 @@ func ecloudRouterListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists routers",
 		Long:    "This command lists routers",
-		Example: "ukfast ecloud router list",
+		Example: "ans ecloud router list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudRouterList),
 	}
 
@@ -70,7 +70,7 @@ func ecloudRouterShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <router: id>...",
 		Short:   "Shows a router",
 		Long:    "This command shows one or more routers",
-		Example: "ukfast ecloud router show rtr-abcdef12",
+		Example: "ans ecloud router show rtr-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing router")
@@ -102,7 +102,7 @@ func ecloudRouterCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates an router",
 		Long:    "This command creates an router",
-		Example: "ukfast ecloud router create --vpc vpc-abcdef12 --availability-zone az-abcdef12",
+		Example: "ans ecloud router create --vpc vpc-abcdef12 --availability-zone az-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudRouterCreate),
 	}
 
@@ -157,7 +157,7 @@ func ecloudRouterUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <router: id>...",
 		Short:   "Updates an router",
 		Long:    "This command updates one or more routers",
-		Example: "ukfast ecloud router update rtr-abcdef12 --name \"my router\"",
+		Example: "ans ecloud router update rtr-abcdef12 --name \"my router\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing router")
@@ -220,7 +220,7 @@ func ecloudRouterDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <router: id>...",
 		Short:   "Removes an router",
 		Long:    "This command removes one or more routers",
-		Example: "ukfast ecloud router delete rtr-abcdef12",
+		Example: "ans ecloud router delete rtr-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing router")
@@ -261,7 +261,7 @@ func ecloudRouterDeployDefaultFirewallPoliciesCmd(f factory.ClientFactory) *cobr
 		Use:     "deploydefaults <router: id>...",
 		Short:   "Deploys default firewall policies for a router",
 		Long:    "This command deploys default firewall policies for one or more routers",
-		Example: "ukfast ecloud router deploydefaultfirewallpolicies rtr-abcdef12",
+		Example: "ans ecloud router deploydefaultfirewallpolicies rtr-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing router")

--- a/cmd/ecloud/ecloud_router_firewallpolicy.go
+++ b/cmd/ecloud/ecloud_router_firewallpolicy.go
@@ -28,7 +28,7 @@ func ecloudRouterFirewallPolicyListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists router firewall policies",
 		Long:    "This command lists router firewall policies",
-		Example: "ukfast ecloud router firewallpolicy list rtr-abcdef12",
+		Example: "ans ecloud router firewallpolicy list rtr-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing router")

--- a/cmd/ecloud/ecloud_router_network.go
+++ b/cmd/ecloud/ecloud_router_network.go
@@ -28,7 +28,7 @@ func ecloudRouterNetworkListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists router networks",
 		Long:    "This command lists router networks",
-		Example: "ukfast ecloud router network list rtr-abcdef12",
+		Example: "ans ecloud router network list rtr-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing router")

--- a/cmd/ecloud/ecloud_router_task.go
+++ b/cmd/ecloud/ecloud_router_task.go
@@ -28,7 +28,7 @@ func ecloudRouterTaskListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <router: id>",
 		Short:   "Lists router tasks",
 		Long:    "This command lists router tasks",
-		Example: "ukfast ecloud router task list rtr-abcdef12",
+		Example: "ans ecloud router task list rtr-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing router")

--- a/cmd/ecloud/ecloud_routerthroughput.go
+++ b/cmd/ecloud/ecloud_routerthroughput.go
@@ -29,7 +29,7 @@ func ecloudRouterThroughputListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists router throughputs",
 		Long:    "This command lists router throughputs",
-		Example: "ukfast ecloud routerthroughput list",
+		Example: "ans ecloud routerthroughput list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudRouterThroughputList),
 	}
 
@@ -61,7 +61,7 @@ func ecloudRouterThroughputShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <routerthroughput: id>...",
 		Short:   "Shows a router throughput",
 		Long:    "This command shows one or more router throughputs",
-		Example: "ukfast ecloud routerthroughput show rtp-abcdef12",
+		Example: "ans ecloud routerthroughput show rtp-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing router throughput")

--- a/cmd/ecloud/ecloud_sshkeypair.go
+++ b/cmd/ecloud/ecloud_sshkeypair.go
@@ -33,7 +33,7 @@ func ecloudSSHKeyPairListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists SSH key pairs",
 		Long:    "This command lists SSH key pairs",
-		Example: "ukfast ecloud sshkeypair list",
+		Example: "ans ecloud sshkeypair list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudSSHKeyPairList),
 	}
 
@@ -63,7 +63,7 @@ func ecloudSSHKeyPairShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <keypair: id>...",
 		Short:   "Shows a SSH key pair",
 		Long:    "This command shows one or more SSH key pairs",
-		Example: "ukfast ecloud sshkeypair show ssh-abcdef12",
+		Example: "ans ecloud sshkeypair show ssh-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing SSH key pair")
@@ -95,7 +95,7 @@ func ecloudSSHKeyPairCreateCmd(f factory.ClientFactory, fs afero.Fs) *cobra.Comm
 		Use:     "create",
 		Short:   "Creates a SSH key pair",
 		Long:    "This command creates a SSH key pair",
-		Example: "ukfast ecloud sshkeypair create --name test --public-key-file ~/.ssh/id_rsa.pub",
+		Example: "ans ecloud sshkeypair create --name test --public-key-file ~/.ssh/id_rsa.pub",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -144,7 +144,7 @@ func ecloudSSHKeyPairUpdateCmd(f factory.ClientFactory, fs afero.Fs) *cobra.Comm
 		Use:     "update <keypair: id>...",
 		Short:   "Updates an SSH key pair",
 		Long:    "This command updates one or more SSH key pairs",
-		Example: "ukfast ecloud sshkeypair update ssh-abcdef12 --name \"my keypair\"",
+		Example: "ans ecloud sshkeypair update ssh-abcdef12 --name \"my keypair\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing SSH key pair")
@@ -210,7 +210,7 @@ func ecloudSSHKeyPairDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <keypair: id>...",
 		Short:   "Removes an SSH key pair",
 		Long:    "This command removes one or more SSH key pairs",
-		Example: "ukfast ecloud sshkeypair delete ssh-abcdef12",
+		Example: "ans ecloud sshkeypair delete ssh-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing SSH key pair")

--- a/cmd/ecloud/ecloud_task.go
+++ b/cmd/ecloud/ecloud_task.go
@@ -30,7 +30,7 @@ func ecloudTaskListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists tasks",
 		Long:    "This command lists tasks",
-		Example: "ukfast ecloud task list",
+		Example: "ans ecloud task list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudTaskList),
 	}
 
@@ -60,7 +60,7 @@ func ecloudTaskShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <task: id>...",
 		Short:   "Shows a task",
 		Long:    "This command shows one or more tasks",
-		Example: "ukfast ecloud task show vol-abcdef12",
+		Example: "ans ecloud task show vol-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing task")
@@ -92,7 +92,7 @@ func ecloudTaskWaitCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "wait <task: id>...",
 		Short:   "Waits for a task",
 		Long:    "This command waits for one or more tasks to have expected status",
-		Example: "ukfast ecloud task wait task-abcdef12",
+		Example: "ans ecloud task wait task-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing task")

--- a/cmd/ecloud/ecloud_v1_credit.go
+++ b/cmd/ecloud/ecloud_v1_credit.go
@@ -28,7 +28,7 @@ func ecloudCreditListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists credits",
 		Long:    "This command lists credits",
-		Example: "ukfast account credit list",
+		Example: "ans account credit list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {

--- a/cmd/ecloud/ecloud_v1_datastore.go
+++ b/cmd/ecloud/ecloud_v1_datastore.go
@@ -30,7 +30,7 @@ func ecloudDatastoreListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists datastores",
 		Long:    "This command lists datastores",
-		Example: "ukfast ecloud datastore list",
+		Example: "ans ecloud datastore list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -61,7 +61,7 @@ func ecloudDatastoreShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <datastore: id>...",
 		Short:   "Shows a datastore",
 		Long:    "This command shows one or more datastores",
-		Example: "ukfast ecloud vm datastore 123",
+		Example: "ans ecloud vm datastore 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing datastore")

--- a/cmd/ecloud/ecloud_v1_firewall.go
+++ b/cmd/ecloud/ecloud_v1_firewall.go
@@ -30,7 +30,7 @@ func ecloudFirewallListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists firewalls",
 		Long:    "This command lists firewalls",
-		Example: "ukfast ecloud firewall list",
+		Example: "ans ecloud firewall list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -61,7 +61,7 @@ func ecloudFirewallShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <firewall: id>...",
 		Short:   "Shows a firewall",
 		Long:    "This command shows one or more firewalls",
-		Example: "ukfast ecloud vm firewall 123",
+		Example: "ans ecloud vm firewall 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing firewall")

--- a/cmd/ecloud/ecloud_v1_host.go
+++ b/cmd/ecloud/ecloud_v1_host.go
@@ -30,7 +30,7 @@ func ecloudV1HostListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists hosts",
 		Long:    "This command lists hosts",
-		Example: "ukfast ecloud v1host list",
+		Example: "ans ecloud v1host list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -61,7 +61,7 @@ func ecloudV1HostShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <host: id>...",
 		Short:   "Shows a host",
 		Long:    "This command shows one or more hosts",
-		Example: "ukfast ecloud v1host 123",
+		Example: "ans ecloud v1host 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing host")

--- a/cmd/ecloud/ecloud_v1_pod.go
+++ b/cmd/ecloud/ecloud_v1_pod.go
@@ -34,7 +34,7 @@ func ecloudPodListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists pods",
 		Long:    "This command lists pods",
-		Example: "ukfast ecloud pod list",
+		Example: "ans ecloud pod list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -65,7 +65,7 @@ func ecloudPodShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <pod: id>...",
 		Short:   "Shows a pod",
 		Long:    "This command shows one or more pods",
-		Example: "ukfast ecloud vm pod 123",
+		Example: "ans ecloud vm pod 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing pod")

--- a/cmd/ecloud/ecloud_v1_pod_appliance.go
+++ b/cmd/ecloud/ecloud_v1_pod_appliance.go
@@ -29,7 +29,7 @@ func ecloudPodApplianceListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists pod appliances",
 		Long:    "This command lists pod appliances",
-		Example: "ukfast ecloud pod appliance list 123",
+		Example: "ans ecloud pod appliance list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing pod")

--- a/cmd/ecloud/ecloud_v1_pod_template.go
+++ b/cmd/ecloud/ecloud_v1_pod_template.go
@@ -32,7 +32,7 @@ func ecloudPodTemplateListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists pod templates",
 		Long:    "This command lists pod templates",
-		Example: "ukfast ecloud pod template list 123",
+		Example: "ans ecloud pod template list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing pod")
@@ -75,7 +75,7 @@ func ecloudPodTemplateShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <pod: id> <template: name>...",
 		Short:   "Shows a pod template",
 		Long:    "This command shows one or more pod templates",
-		Example: "ukfast ecloud pod template show 123 foo",
+		Example: "ans ecloud pod template show 123 foo",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing pod")
@@ -123,7 +123,7 @@ func ecloudPodTemplateUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <pod: id> <template: name>...",
 		Short:   "Updates a pod template",
 		Long:    "This command updates a pod template",
-		Example: "ukfast ecloud pod template update 123 foo --name \"bar\"",
+		Example: "ans ecloud pod template update 123 foo --name \"bar\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing pod")
@@ -189,7 +189,7 @@ func ecloudPodTemplateDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <pod: id> <template: name>...",
 		Short:   "Removes a pod template ",
 		Long:    "This command removes one or more pod templates",
-		Example: "ukfast ecloud pod template delete 123 foo",
+		Example: "ans ecloud pod template delete 123 foo",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing pod")

--- a/cmd/ecloud/ecloud_v1_site.go
+++ b/cmd/ecloud/ecloud_v1_site.go
@@ -30,7 +30,7 @@ func ecloudSiteListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists sites",
 		Long:    "This command lists sites",
-		Example: "ukfast ecloud site list",
+		Example: "ans ecloud site list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -65,7 +65,7 @@ func ecloudSiteShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <site: id>...",
 		Short:   "Shows a site",
 		Long:    "This command shows one or more sites",
-		Example: "ukfast ecloud vm site 123",
+		Example: "ans ecloud vm site 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing site")

--- a/cmd/ecloud/ecloud_v1_solution.go
+++ b/cmd/ecloud/ecloud_v1_solution.go
@@ -42,7 +42,7 @@ func ecloudSolutionListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists solutions",
 		Long:    "This command lists solutions",
-		Example: "ukfast ecloud solution list",
+		Example: "ans ecloud solution list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -77,7 +77,7 @@ func ecloudSolutionShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <solution: id>...",
 		Short:   "Shows a solution",
 		Long:    "This command shows one or more solutions",
-		Example: "ukfast ecloud solution show 123",
+		Example: "ans ecloud solution show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")
@@ -122,7 +122,7 @@ func ecloudSolutionUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <solution: id>",
 		Short:   "Updates a solution",
 		Long:    "This command updates a solution",
-		Example: "ukfast ecloud solution update 123 --name \"new name\"",
+		Example: "ans ecloud solution update 123 --name \"new name\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/ecloud/ecloud_v1_solution_datastore.go
+++ b/cmd/ecloud/ecloud_v1_solution_datastore.go
@@ -29,7 +29,7 @@ func ecloudSolutionDatastoreListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists solution datastores",
 		Long:    "This command lists solution datastores",
-		Example: "ukfast ecloud solution datastore list 123",
+		Example: "ans ecloud solution datastore list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/ecloud/ecloud_v1_solution_firewall.go
+++ b/cmd/ecloud/ecloud_v1_solution_firewall.go
@@ -29,7 +29,7 @@ func ecloudSolutionFirewallListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists solution firewalls",
 		Long:    "This command lists solution firewalls",
-		Example: "ukfast ecloud solution firewall list 123",
+		Example: "ans ecloud solution firewall list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/ecloud/ecloud_v1_solution_host.go
+++ b/cmd/ecloud/ecloud_v1_solution_host.go
@@ -29,7 +29,7 @@ func ecloudSolutionHostListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists solution hosts",
 		Long:    "This command lists solution hosts",
-		Example: "ukfast ecloud solution host list 123",
+		Example: "ans ecloud solution host list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/ecloud/ecloud_v1_solution_network.go
+++ b/cmd/ecloud/ecloud_v1_solution_network.go
@@ -29,7 +29,7 @@ func ecloudSolutionNetworkListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists solution networks",
 		Long:    "This command lists solution networks",
-		Example: "ukfast ecloud solution network list 123",
+		Example: "ans ecloud solution network list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/ecloud/ecloud_v1_solution_site.go
+++ b/cmd/ecloud/ecloud_v1_solution_site.go
@@ -29,7 +29,7 @@ func ecloudSolutionSiteListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists solution sites",
 		Long:    "This command lists solution sites",
-		Example: "ukfast ecloud solution site list 123",
+		Example: "ans ecloud solution site list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/ecloud/ecloud_v1_solution_tag.go
+++ b/cmd/ecloud/ecloud_v1_solution_tag.go
@@ -34,7 +34,7 @@ func ecloudSolutionTagListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <solution: id>",
 		Short:   "lists solution tags",
 		Long:    "This command lists solution tags",
-		Example: "ukfast ecloud solution tag list 123",
+		Example: "ans ecloud solution tag list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")
@@ -77,7 +77,7 @@ func ecloudSolutionTagShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <solution: id> <tag: key>...",
 		Short:   "Shows a solution tag",
 		Long:    "This command shows one or more solution tags",
-		Example: "ukfast ecloud solution tag show 123 foo",
+		Example: "ans ecloud solution tag show 123 foo",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")
@@ -125,7 +125,7 @@ func ecloudSolutionTagCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <solution: id>",
 		Short:   "Creates a solution tag",
 		Long:    "This command creates a solution tag",
-		Example: "ukfast ecloud solution tag create 123 --key foo --value bar",
+		Example: "ans ecloud solution tag create 123 --key foo --value bar",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")
@@ -183,7 +183,7 @@ func ecloudSolutionTagUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <solution: id> <tag: key>...",
 		Short:   "Updates a solution tag",
 		Long:    "This command updates one or more solution tags",
-		Example: "ukfast ecloud solution tag update 123 foo --value \"new value\"",
+		Example: "ans ecloud solution tag update 123 foo --value \"new value\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")
@@ -248,7 +248,7 @@ func ecloudSolutionTagDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <solution: id> <tag: key>...",
 		Short:   "Removes a solution tag ",
 		Long:    "This command removes one or more solution tags",
-		Example: "ukfast ecloud solution tag delete 123 foo",
+		Example: "ans ecloud solution tag delete 123 foo",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/ecloud/ecloud_v1_solution_template.go
+++ b/cmd/ecloud/ecloud_v1_solution_template.go
@@ -32,7 +32,7 @@ func ecloudSolutionTemplateListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists solution templates",
 		Long:    "This command lists solution templates",
-		Example: "ukfast ecloud solution template list 123",
+		Example: "ans ecloud solution template list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")
@@ -75,7 +75,7 @@ func ecloudSolutionTemplateShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <solution: id> <template: name>...",
 		Short:   "Shows a solution template",
 		Long:    "This command shows one or more solution templates",
-		Example: "ukfast ecloud solution template show 123 foo",
+		Example: "ans ecloud solution template show 123 foo",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")
@@ -123,7 +123,7 @@ func ecloudSolutionTemplateUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <solution: id> <template: name>...",
 		Short:   "Updates a solution template",
 		Long:    "This command updates a solution template",
-		Example: "ukfast ecloud solution template update 123 foo --name \"bar\"",
+		Example: "ans ecloud solution template update 123 foo --name \"bar\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")
@@ -189,7 +189,7 @@ func ecloudSolutionTemplateDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <solution: id> <template: name>...",
 		Short:   "Removes a solution template ",
 		Long:    "This command removes one or more solution templates",
-		Example: "ukfast ecloud solution template delete 123 foo",
+		Example: "ans ecloud solution template delete 123 foo",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/ecloud/ecloud_v1_solution_vm.go
+++ b/cmd/ecloud/ecloud_v1_solution_vm.go
@@ -29,7 +29,7 @@ func ecloudSolutionVirtualMachineListCmd(f factory.ClientFactory) *cobra.Command
 		Use:     "list",
 		Short:   "Lists solution virtual machines",
 		Long:    "This command lists solution virtual machines",
-		Example: "ukfast ecloud solution vm list 123",
+		Example: "ans ecloud solution vm list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/ecloud/ecloud_v1_vm.go
+++ b/cmd/ecloud/ecloud_v1_vm.go
@@ -43,7 +43,7 @@ func ecloudVirtualMachineListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists virtual machines",
 		Long:    "This command lists virtual machines",
-		Example: "ukfast ecloud vm list",
+		Example: "ans ecloud vm list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -78,7 +78,7 @@ func ecloudVirtualMachineShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <virtualmachine: id>...",
 		Short:   "Shows a virtual machine",
 		Long:    "This command shows one or more virtual machines",
-		Example: "ukfast ecloud vm show 123",
+		Example: "ans ecloud vm show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing virtual machine")
@@ -123,7 +123,7 @@ func ecloudVirtualMachineCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a virtual machine",
 		Long:    "This command creates a virtual machine",
-		Example: "ukfast ecloud vm create",
+		Example: "ans ecloud vm create",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -248,7 +248,7 @@ func ecloudVirtualMachineUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <virtualmachine: id>...",
 		Short:   "Updates a virtual machine",
 		Long:    "This command updates one or more virtual machines",
-		Example: "ukfast ecloud vm update 123 --name \"test vm 1\"",
+		Example: "ans ecloud vm update 123 --name \"test vm 1\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing virtual machine")
@@ -329,7 +329,7 @@ func ecloudVirtualMachineStartCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "start <virtualmachine: id>...",
 		Short:   "Starts a virtual machine",
 		Long:    "This command starts one or more virtual machines",
-		Example: "ukfast ecloud vm start 123",
+		Example: "ans ecloud vm start 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing virtual machine")
@@ -370,7 +370,7 @@ func ecloudVirtualMachineStopCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "stop <virtualmachine: id>...",
 		Short:   "Stops a virtual machine",
 		Long:    "This command stops one or more virtual machines",
-		Example: "ukfast ecloud vm stop 123",
+		Example: "ans ecloud vm stop 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing virtual machine")
@@ -425,7 +425,7 @@ func ecloudVirtualMachineRestartCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "restart <virtualmachine: id>...",
 		Short:   "Restarts a virtual machine",
 		Long:    "This command restarts one or more virtual machines",
-		Example: "ukfast ecloud vm restart 123",
+		Example: "ans ecloud vm restart 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing virtual machine")
@@ -480,7 +480,7 @@ func ecloudVirtualMachineDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <virtualmachine: id>...",
 		Short:   "Removes a virtual machine",
 		Long:    "This command removes one or more virtual machines",
-		Example: "ukfast ecloud vm delete 123",
+		Example: "ans ecloud vm delete 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing virtual machine")

--- a/cmd/ecloud/ecloud_v1_vm_consolesession.go
+++ b/cmd/ecloud/ecloud_v1_vm_consolesession.go
@@ -30,7 +30,7 @@ func ecloudVirtualMachineConsoleSessionCreateCmd(f factory.ClientFactory) *cobra
 		Use:     "create <virtualmachine: id>",
 		Short:   "Creates a virtual machine console session",
 		Long:    "This command creates a virtual machine console session",
-		Example: "ukfast ecloud vm consolesession create 123",
+		Example: "ans ecloud vm consolesession create 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing virtual machine")

--- a/cmd/ecloud/ecloud_v1_vm_disk.go
+++ b/cmd/ecloud/ecloud_v1_vm_disk.go
@@ -31,7 +31,7 @@ func ecloudVirtualMachineDiskListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <virtualmachine: id>",
 		Short:   "lists virtual machine disks",
 		Long:    "This command lists virtual machine disks",
-		Example: "ukfast ecloud vm disk list 123",
+		Example: "ans ecloud vm disk list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing virtual machine")
@@ -73,7 +73,7 @@ func ecloudVirtualMachineDiskUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <virtualmachine: id> <disk: id>",
 		Short:   "Updates a virtual machine disk",
 		Long:    "This command updates a virtual machine disk",
-		Example: "ukfast ecloud vm disk update 123 00000000-0000-0000-0000-000000000000 --capacity 25",
+		Example: "ans ecloud vm disk update 123 00000000-0000-0000-0000-000000000000 --capacity 25",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing virtual machine")

--- a/cmd/ecloud/ecloud_v1_vm_tag.go
+++ b/cmd/ecloud/ecloud_v1_vm_tag.go
@@ -34,7 +34,7 @@ func ecloudVirtualMachineTagListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <virtualmachine: id>",
 		Short:   "lists virtual machine tags",
 		Long:    "This command lists virtual machine tags",
-		Example: "ukfast ecloud vm tag list 123",
+		Example: "ans ecloud vm tag list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing virtual machine")
@@ -77,7 +77,7 @@ func ecloudVirtualMachineTagShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <virtualmachine: id> <tag: key>...",
 		Short:   "Shows a virtual machine tag",
 		Long:    "This command shows one or more virtual machine tags",
-		Example: "ukfast ecloud vm tag show 123 foo",
+		Example: "ans ecloud vm tag show 123 foo",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing virtual machine")
@@ -125,7 +125,7 @@ func ecloudVirtualMachineTagCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <virtualmachine: id>",
 		Short:   "Creates a virtual machine tag",
 		Long:    "This command creates a virtual machine tag",
-		Example: "ukfast ecloud vm tag create 123 --key foo --value bar",
+		Example: "ans ecloud vm tag create 123 --key foo --value bar",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing virtual machine")
@@ -183,7 +183,7 @@ func ecloudVirtualMachineTagUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <virtualmachine: id> <tag: key>...",
 		Short:   "Updates a virtual machine tag",
 		Long:    "This command updates one or more virtual machine tags",
-		Example: "ukfast ecloud vm tag update 123 foo --value \"new value\"",
+		Example: "ans ecloud vm tag update 123 foo --value \"new value\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing virtual machine")
@@ -248,7 +248,7 @@ func ecloudVirtualMachineTagDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <virtualmachine: id> <tag: key>...",
 		Short:   "Removes a virtual machine tag ",
 		Long:    "This command removes one or more virtual machine tags",
-		Example: "ukfast ecloud vm tag delete 123 foo",
+		Example: "ans ecloud vm tag delete 123 foo",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing virtual machine")

--- a/cmd/ecloud/ecloud_v1_vm_template.go
+++ b/cmd/ecloud/ecloud_v1_vm_template.go
@@ -30,7 +30,7 @@ func ecloudVirtualMachineTemplateCreateCmd(f factory.ClientFactory) *cobra.Comma
 		Use:     "create <virtualmachine: id>",
 		Short:   "Creates a virtual machine template",
 		Long:    "This command creates a virtual machine template",
-		Example: "ukfast ecloud vm template create 123 --name \"foo\" --type \"solution\"",
+		Example: "ans ecloud vm template create 123 --name \"foo\" --type \"solution\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing virtual machine")

--- a/cmd/ecloud/ecloud_vip.go
+++ b/cmd/ecloud/ecloud_vip.go
@@ -32,7 +32,7 @@ func ecloudVIPListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists VIPs",
 		Long:    "This command lists VIPs",
-		Example: "ukfast ecloud vip list",
+		Example: "ans ecloud vip list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudVIPList),
 	}
 
@@ -64,7 +64,7 @@ func ecloudVIPShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <vip: id>...",
 		Short:   "Shows an VIP",
 		Long:    "This command shows one or more VIPs",
-		Example: "ukfast ecloud vip show vip-abcdef12",
+		Example: "ans ecloud vip show vip-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VIP")
@@ -96,7 +96,7 @@ func ecloudVIPCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a VIP",
 		Long:    "This command creates a VIP",
-		Example: "ukfast ecloud vip create --name testvip --load-balancer lb-abcdef12",
+		Example: "ans ecloud vip create --name testvip --load-balancer lb-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudVIPCreate),
 	}
 
@@ -142,7 +142,7 @@ func ecloudVIPUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <vip: id>...",
 		Short:   "Updates a VIP",
 		Long:    "This command updates one or more VIPs",
-		Example: "ukfast ecloud vip update vip-abcdef12 --name \"my vip\"",
+		Example: "ans ecloud vip update vip-abcdef12 --name \"my vip\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VIP")
@@ -200,7 +200,7 @@ func ecloudVIPDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <vip: id>...",
 		Short:   "Removes a VIP",
 		Long:    "This command removes one or more VIPs",
-		Example: "ukfast ecloud vip delete vip-abcdef12",
+		Example: "ans ecloud vip delete vip-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VIP")

--- a/cmd/ecloud/ecloud_volume.go
+++ b/cmd/ecloud/ecloud_volume.go
@@ -37,7 +37,7 @@ func ecloudVolumeListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists volumes",
 		Long:    "This command lists volumes",
-		Example: "ukfast ecloud volume list",
+		Example: "ans ecloud volume list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudVolumeList),
 	}
 
@@ -69,7 +69,7 @@ func ecloudVolumeShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <volume: id>...",
 		Short:   "Shows a volume",
 		Long:    "This command shows one or more volumes",
-		Example: "ukfast ecloud volume show vol-abcdef12",
+		Example: "ans ecloud volume show vol-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing volume")
@@ -101,7 +101,7 @@ func ecloudVolumeCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a volume",
 		Long:    "This command creates a volume",
-		Example: "ukfast ecloud volume create",
+		Example: "ans ecloud volume create",
 		RunE:    ecloudCobraRunEFunc(f, ecloudVolumeCreate),
 	}
 
@@ -157,7 +157,7 @@ func ecloudVolumeUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <volume: id>...",
 		Short:   "Updates a volume",
 		Long:    "This command updates one or more volumes",
-		Example: "ukfast ecloud volume update vol-abcdef12 --name \"my volume\"",
+		Example: "ans ecloud volume update vol-abcdef12 --name \"my volume\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing volume")
@@ -231,7 +231,7 @@ func ecloudVolumeDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <volume: id>...",
 		Short:   "Removes a volume",
 		Long:    "This command removes one or more volumes",
-		Example: "ukfast ecloud volume delete vol-abcdef12",
+		Example: "ans ecloud volume delete vol-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing volume")

--- a/cmd/ecloud/ecloud_volume_instance.go
+++ b/cmd/ecloud/ecloud_volume_instance.go
@@ -28,7 +28,7 @@ func ecloudVolumeInstanceListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists volume instances",
 		Long:    "This command lists volume instances",
-		Example: "ukfast ecloud volume instance list vol-abcdef12",
+		Example: "ans ecloud volume instance list vol-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing volume")

--- a/cmd/ecloud/ecloud_volume_task.go
+++ b/cmd/ecloud/ecloud_volume_task.go
@@ -28,7 +28,7 @@ func ecloudVolumeTaskListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <volume: id>",
 		Short:   "Lists volume tasks",
 		Long:    "This command lists volume tasks",
-		Example: "ukfast ecloud volume task list vol-abcdef12",
+		Example: "ans ecloud volume task list vol-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing volume")

--- a/cmd/ecloud/ecloud_volumegroup.go
+++ b/cmd/ecloud/ecloud_volumegroup.go
@@ -35,7 +35,7 @@ func ecloudVolumeGroupListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists volumegroups",
 		Long:    "This command lists volumegroups",
-		Example: "ukfast ecloud volumegroup list",
+		Example: "ans ecloud volumegroup list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudVolumeGroupList),
 	}
 
@@ -67,7 +67,7 @@ func ecloudVolumeGroupShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <volumegroup: id>...",
 		Short:   "Shows a volumegroup",
 		Long:    "This command shows one or more volumegroups",
-		Example: "ukfast ecloud volumegroup show vol-abcdef12",
+		Example: "ans ecloud volumegroup show vol-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing volume-group")
@@ -99,7 +99,7 @@ func ecloudVolumeGroupCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a volumegroup",
 		Long:    "This command creates a volumegroup",
-		Example: "ukfast ecloud volumegroup create",
+		Example: "ans ecloud volumegroup create",
 		RunE:    ecloudCobraRunEFunc(f, ecloudVolumeGroupCreate),
 	}
 
@@ -148,7 +148,7 @@ func ecloudVolumeGroupUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <volumegroup: id>...",
 		Short:   "Updates a volumegroup",
 		Long:    "This command updates one or more volumegroups",
-		Example: "ukfast ecloud volumegroup update volgroup-abcdef12 --name \"my volumegroup\"",
+		Example: "ans ecloud volumegroup update volgroup-abcdef12 --name \"my volumegroup\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing volume-group")
@@ -206,7 +206,7 @@ func ecloudVolumeGroupDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <volumegroup: id>...",
 		Short:   "Removes a volumegroup",
 		Long:    "This command removes one or more volumegroups",
-		Example: "ukfast ecloud volumegroup delete vol-abcdef12",
+		Example: "ans ecloud volumegroup delete vol-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing volume-group")

--- a/cmd/ecloud/ecloud_volumegroup_volume.go
+++ b/cmd/ecloud/ecloud_volumegroup_volume.go
@@ -28,7 +28,7 @@ func ecloudVolumeGroupVolumeListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists volumegroup volumes",
 		Long:    "This command lists volumegroup volumes",
-		Example: "ukfast ecloud volumegroup volume list volgroup-abcdef12",
+		Example: "ans ecloud volumegroup volume list volgroup-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing volume-group")

--- a/cmd/ecloud/ecloud_vpc.go
+++ b/cmd/ecloud/ecloud_vpc.go
@@ -38,7 +38,7 @@ func ecloudVPCListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists VPCs",
 		Long:    "This command lists VPCs",
-		Example: "ukfast ecloud vpc list",
+		Example: "ans ecloud vpc list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudVPCList),
 	}
 
@@ -66,7 +66,7 @@ func ecloudVPCShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <vpc: id>...",
 		Short:   "Shows a VPC",
 		Long:    "This command shows one or more VPCs",
-		Example: "ukfast ecloud vpc show vpc-abcdef12",
+		Example: "ans ecloud vpc show vpc-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing vpc")
@@ -98,7 +98,7 @@ func ecloudVPCCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a VPC",
 		Long:    "This command creates a VPC",
-		Example: "ukfast ecloud vpc create",
+		Example: "ans ecloud vpc create",
 		RunE:    ecloudCobraRunEFunc(f, ecloudVPCCreate),
 	}
 
@@ -147,7 +147,7 @@ func ecloudVPCUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <vpc: id>...",
 		Short:   "Updates a VPC",
 		Long:    "This command updates one or more VPCs",
-		Example: "ukfast ecloud vpc update vpc-abcdef12 --name \"my vpc\"",
+		Example: "ans ecloud vpc update vpc-abcdef12 --name \"my vpc\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing vpc")
@@ -206,7 +206,7 @@ func ecloudVPCDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <vpc: id>...",
 		Short:   "Removes a VPC",
 		Long:    "This command removes one or more VPCs",
-		Example: "ukfast ecloud vpc delete vpc-abcdef12",
+		Example: "ans ecloud vpc delete vpc-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing vpc")
@@ -254,7 +254,7 @@ func ecloudVPCDeployDefaultsCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "deploydefaults <vpc: id>...",
 		Short:   "Deploys default resources for a VPC",
 		Long:    "This command deploys default resources for one or more VPCs",
-		Example: "ukfast ecloud vpc deploydefaults vpc-abcdef12",
+		Example: "ans ecloud vpc deploydefaults vpc-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing vpc")

--- a/cmd/ecloud/ecloud_vpc_instance.go
+++ b/cmd/ecloud/ecloud_vpc_instance.go
@@ -28,7 +28,7 @@ func ecloudVPCInstanceListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists VPC instances",
 		Long:    "This command lists VPC instances",
-		Example: "ukfast ecloud vpc instance list net-abcdef12",
+		Example: "ans ecloud vpc instance list net-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VPC")

--- a/cmd/ecloud/ecloud_vpc_task.go
+++ b/cmd/ecloud/ecloud_vpc_task.go
@@ -28,7 +28,7 @@ func ecloudVPCTaskListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <vpc: id>",
 		Short:   "Lists VPC tasks",
 		Long:    "This command lists VPC tasks",
-		Example: "ukfast ecloud vpc task list vpc-abcdef12",
+		Example: "ans ecloud vpc task list vpc-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VPC")

--- a/cmd/ecloud/ecloud_vpc_volume.go
+++ b/cmd/ecloud/ecloud_vpc_volume.go
@@ -28,7 +28,7 @@ func ecloudVPCVolumeListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists VPC volumes",
 		Long:    "This command lists VPC volumes",
-		Example: "ukfast ecloud vpc volume list vpc-abcdef12",
+		Example: "ans ecloud vpc volume list vpc-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VPC")

--- a/cmd/ecloud/ecloud_vpnendpoint.go
+++ b/cmd/ecloud/ecloud_vpnendpoint.go
@@ -32,7 +32,7 @@ func ecloudVPNEndpointListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists VPN endpoints",
 		Long:    "This command lists VPN endpoints",
-		Example: "ukfast ecloud vpnendpoint list",
+		Example: "ans ecloud vpnendpoint list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudVPNEndpointList),
 	}
 
@@ -62,7 +62,7 @@ func ecloudVPNEndpointShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <endpoint: id>...",
 		Short:   "Shows a VPN endpoint",
 		Long:    "This command shows one or more VPN endpoints",
-		Example: "ukfast ecloud vpnendpoint show vpne-abcdef12",
+		Example: "ans ecloud vpnendpoint show vpne-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VPN endpoint")
@@ -94,7 +94,7 @@ func ecloudVPNEndpointCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a VPN endpoint",
 		Long:    "This command creates a VPN endpoint",
-		Example: "ukfast ecloud vpnendpoint create --router rtr-abcdef12",
+		Example: "ans ecloud vpnendpoint create --router rtr-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudVPNEndpointCreate),
 	}
 
@@ -140,7 +140,7 @@ func ecloudVPNEndpointUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <endpoint: id>...",
 		Short:   "Updates a VPN endpoint",
 		Long:    "This command updates one or more VPN endpoints",
-		Example: "ukfast ecloud vpnendpoint update vpne-abcdef12 --name \"my endpoint\"",
+		Example: "ans ecloud vpnendpoint update vpne-abcdef12 --name \"my endpoint\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VPN endpoint")
@@ -198,7 +198,7 @@ func ecloudVPNEndpointDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <endpoint: id>...",
 		Short:   "Removes a VPN endpoint",
 		Long:    "This command removes one or more VPN endpoints",
-		Example: "ukfast ecloud vpnendpoint delete vpne-abcdef12",
+		Example: "ans ecloud vpnendpoint delete vpne-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VPN endpoint")

--- a/cmd/ecloud/ecloud_vpnprofilegroup.go
+++ b/cmd/ecloud/ecloud_vpnprofilegroup.go
@@ -29,7 +29,7 @@ func ecloudVPNProfileGroupListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists VPN sessions",
 		Long:    "This command lists VPN sessions",
-		Example: "ukfast ecloud vpnprofilegroup list",
+		Example: "ans ecloud vpnprofilegroup list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudVPNProfileGroupList),
 	}
 
@@ -59,7 +59,7 @@ func ecloudVPNProfileGroupShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <session: id>...",
 		Short:   "Shows a VPN session",
 		Long:    "This command shows one or more VPN sessions",
-		Example: "ukfast ecloud vpnprofilegroup show vpns-abcdef12",
+		Example: "ans ecloud vpnprofilegroup show vpns-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VPN session")

--- a/cmd/ecloud/ecloud_vpnservice.go
+++ b/cmd/ecloud/ecloud_vpnservice.go
@@ -32,7 +32,7 @@ func ecloudVPNServiceListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists VPN services",
 		Long:    "This command lists VPN services",
-		Example: "ukfast ecloud vpnservice list",
+		Example: "ans ecloud vpnservice list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudVPNServiceList),
 	}
 
@@ -62,7 +62,7 @@ func ecloudVPNServiceShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <service: id>...",
 		Short:   "Shows a VPN service",
 		Long:    "This command shows one or more VPN services",
-		Example: "ukfast ecloud vpnservice show vpn-abcdef12",
+		Example: "ans ecloud vpnservice show vpn-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VPN service")
@@ -94,7 +94,7 @@ func ecloudVPNServiceCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a VPN service",
 		Long:    "This command creates a VPN service",
-		Example: "ukfast ecloud vpnservice create --router rtr-abcdef12",
+		Example: "ans ecloud vpnservice create --router rtr-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudVPNServiceCreate),
 	}
 
@@ -138,7 +138,7 @@ func ecloudVPNServiceUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <service: id>...",
 		Short:   "Updates a VPN service",
 		Long:    "This command updates one or more VPN services",
-		Example: "ukfast ecloud vpnservice update vpn-abcdef12 --name \"my service\"",
+		Example: "ans ecloud vpnservice update vpn-abcdef12 --name \"my service\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VPN service")
@@ -196,7 +196,7 @@ func ecloudVPNServiceDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <service: id>...",
 		Short:   "Removes a VPN service",
 		Long:    "This command removes one or more VPN services",
-		Example: "ukfast ecloud vpnservice delete vpn-abcdef12",
+		Example: "ans ecloud vpnservice delete vpn-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VPN service")

--- a/cmd/ecloud/ecloud_vpnsession.go
+++ b/cmd/ecloud/ecloud_vpnsession.go
@@ -36,7 +36,7 @@ func ecloudVPNSessionListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists VPN sessions",
 		Long:    "This command lists VPN sessions",
-		Example: "ukfast ecloud vpnsession list",
+		Example: "ans ecloud vpnsession list",
 		RunE:    ecloudCobraRunEFunc(f, ecloudVPNSessionList),
 	}
 
@@ -66,7 +66,7 @@ func ecloudVPNSessionShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <session: id>...",
 		Short:   "Shows a VPN session",
 		Long:    "This command shows one or more VPN sessions",
-		Example: "ukfast ecloud vpnsession show vpns-abcdef12",
+		Example: "ans ecloud vpnsession show vpns-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VPN session")
@@ -98,7 +98,7 @@ func ecloudVPNSessionCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a VPN session",
 		Long:    "This command creates a VPN session",
-		Example: "ukfast ecloud vpnsession create --router rtr-abcdef12",
+		Example: "ans ecloud vpnsession create --router rtr-abcdef12",
 		RunE:    ecloudCobraRunEFunc(f, ecloudVPNSessionCreate),
 	}
 
@@ -158,7 +158,7 @@ func ecloudVPNSessionUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <session: id>...",
 		Short:   "Updates a VPN session",
 		Long:    "This command updates one or more VPN sessions",
-		Example: "ukfast ecloud vpnsession update vpns-abcdef12 --name \"my session\"",
+		Example: "ans ecloud vpnsession update vpns-abcdef12 --name \"my session\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VPN session")
@@ -226,7 +226,7 @@ func ecloudVPNSessionDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <session: id>...",
 		Short:   "Removes a VPN session",
 		Long:    "This command removes one or more VPN sessions",
-		Example: "ukfast ecloud vpnsession delete vpns-abcdef12",
+		Example: "ans ecloud vpnsession delete vpns-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VPN session")

--- a/cmd/ecloud/ecloud_vpnsession_presharedkey.go
+++ b/cmd/ecloud/ecloud_vpnsession_presharedkey.go
@@ -29,7 +29,7 @@ func ecloudVPNSessionPreSharedKeyShowCmd(f factory.ClientFactory) *cobra.Command
 		Use:     "show",
 		Short:   "Shows VPN session pre-shared keys",
 		Long:    "This command shows VPN session pre-shared keys",
-		Example: "ukfast ecloud vpnsession presharedkey show vpns-abcdef12",
+		Example: "ans ecloud vpnsession presharedkey show vpns-abcdef12",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VPN session")
@@ -61,7 +61,7 @@ func ecloudVPNSessionPreSharedKeyUpdateCmd(f factory.ClientFactory) *cobra.Comma
 		Use:     "update <session: id>...",
 		Short:   "Updates the pre-shared key for a VPN session",
 		Long:    "This command updates the pre-shared key for a VPN session",
-		Example: "ukfast ecloud vpnsession presharedkey update vpns-abcdef12 --psk \"s3curePSK\"",
+		Example: "ans ecloud vpnsession presharedkey update vpns-abcdef12 --psk \"s3curePSK\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing VPN session")

--- a/cmd/ecloudflex/ecloudflex_project.go
+++ b/cmd/ecloudflex/ecloudflex_project.go
@@ -30,7 +30,7 @@ func ecloudflexProjectListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists projects",
 		Long:    "This command lists projects",
-		Example: "ukfast ecloudflex project list",
+		Example: "ans ecloudflex project list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -61,7 +61,7 @@ func ecloudflexProjectShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <project: id>...",
 		Short:   "Shows a project",
 		Long:    "This command shows one or more projects",
-		Example: "ukfast ecloudflex project show 123",
+		Example: "ans ecloudflex project show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing project")

--- a/cmd/loadbalancer/loadbalancer_accessip.go
+++ b/cmd/loadbalancer/loadbalancer_accessip.go
@@ -30,7 +30,7 @@ func loadbalancerAccessIPShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <accessip: id>...",
 		Short:   "Shows an access IP",
 		Long:    "This command shows one or more access IPs",
-		Example: "ukfast loadbalancer accessip show 123",
+		Example: "ans loadbalancer accessip show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing access IP")
@@ -68,7 +68,7 @@ func loadbalancerAccessIPUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <accessip: id>...",
 		Short:   "Updates an access IP",
 		Long:    "This command updates one or more access IPs",
-		Example: "ukfast loadbalancer accessip update 123 --ip 1.2.3.4",
+		Example: "ans loadbalancer accessip update 123 --ip 1.2.3.4",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing access IP")
@@ -122,7 +122,7 @@ func loadbalancerAccessIPDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <accessip: id>...",
 		Short:   "Removes an access IP",
 		Long:    "This command removes one or more access IPs",
-		Example: "ukfast loadbalancer accessip delete 123",
+		Example: "ans loadbalancer accessip delete 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing access IP")

--- a/cmd/loadbalancer/loadbalancer_acl.go
+++ b/cmd/loadbalancer/loadbalancer_acl.go
@@ -32,7 +32,7 @@ func loadbalancerACLShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <acl: id>...",
 		Short:   "Shows an ACL",
 		Long:    "This command shows one or more ACLs",
-		Example: "ukfast loadbalancer acl show 123",
+		Example: "ans loadbalancer acl show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing ACL")
@@ -70,7 +70,7 @@ func loadbalancerACLCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <acl: id>",
 		Short:   "Creates an ACL",
 		Long:    "This command creates a ACLs with a single condition/action. Additional conditions/actions can be added with subcommands",
-		Example: "ukfast loadbalancer acl create --name \"test ACL\" --host-group 1 --condition \"header_matches:host=ukfast.co.uk,accept=application/json\" --action \"redirect:location=developers.ukfast.io,status=302\"",
+		Example: "ans loadbalancer acl create --name \"test ACL\" --host-group 1 --condition \"header_matches:host=ans.co.uk,accept=application/json\" --action \"redirect:location=developers.ukfast.io,status=302\"",
 		RunE:    loadbalancerCobraRunEFunc(f, loadbalancerACLCreate),
 	}
 
@@ -78,7 +78,7 @@ func loadbalancerACLCreateCmd(f factory.ClientFactory) *cobra.Command {
 	cmd.MarkFlagRequired("name")
 	cmd.Flags().Int("listener", 0, "ID of listener")
 	cmd.Flags().Int("target-group", 0, "ID of target group")
-	cmd.Flags().StringArray("condition", []string{}, "Name and arguments of condition. Can be repeated. Example: --condition \"header_matches:host=ukfast.co.uk,accept=application/json\"")
+	cmd.Flags().StringArray("condition", []string{}, "Name and arguments of condition. Can be repeated. Example: --condition \"header_matches:host=ans.co.uk,accept=application/json\"")
 	cmd.Flags().StringArray("action", []string{}, "Name and arguments of action. Can be repeated. Example: --action \"redirect:location=developers.ukfast.io,status=302\"")
 	cmd.MarkFlagRequired("action")
 
@@ -127,7 +127,7 @@ func loadbalancerACLUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <acl: id>...",
 		Short:   "Updates an ACL",
 		Long:    "This command updates one or more ACLs",
-		Example: "ukfast loadbalancer acl update 123 --name myacl",
+		Example: "ans loadbalancer acl update 123 --name myacl",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing ACL")
@@ -139,7 +139,7 @@ func loadbalancerACLUpdateCmd(f factory.ClientFactory) *cobra.Command {
 	}
 
 	cmd.Flags().String("name", "", "Name of ACL")
-	cmd.Flags().StringArray("condition", []string{}, "Name and arguments of condition. Can be repeated. Example: --condition \"header_matches:host=ukfast.co.uk,accept=application/json\"")
+	cmd.Flags().StringArray("condition", []string{}, "Name and arguments of condition. Can be repeated. Example: --condition \"header_matches:host=ans.co.uk,accept=application/json\"")
 	cmd.Flags().StringArray("action", []string{}, "Name and arguments of action. Can be repeated. Example: --action \"redirect:location=developers.ukfast.io,status=302\"")
 
 	return cmd
@@ -198,7 +198,7 @@ func loadbalancerACLDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <acl: id>...",
 		Short:   "Removes a acl",
 		Long:    "This command removes one or more acls",
-		Example: "ukfast loadbalancer acl delete 123",
+		Example: "ans loadbalancer acl delete 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing ACL")

--- a/cmd/loadbalancer/loadbalancer_bind.go
+++ b/cmd/loadbalancer/loadbalancer_bind.go
@@ -27,7 +27,7 @@ func loadbalancerBindListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists binds",
 		Long:    "This command lists binds",
-		Example: "ukfast loadbalancer bind list",
+		Example: "ans loadbalancer bind list",
 		RunE:    loadbalancerCobraRunEFunc(f, loadbalancerBindList),
 	}
 }

--- a/cmd/loadbalancer/loadbalancer_cluster.go
+++ b/cmd/loadbalancer/loadbalancer_cluster.go
@@ -36,7 +36,7 @@ func loadbalancerClusterListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists clusters",
 		Long:    "This command lists clusters",
-		Example: "ukfast loadbalancer cluster list",
+		Example: "ans loadbalancer cluster list",
 		RunE:    loadbalancerCobraRunEFunc(f, loadbalancerClusterList),
 	}
 }
@@ -60,7 +60,7 @@ func loadbalancerClusterShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <cluster: id>...",
 		Short:   "Shows a cluster",
 		Long:    "This command shows one or more clusters",
-		Example: "ukfast loadbalancer cluster show 123",
+		Example: "ans loadbalancer cluster show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing cluster")
@@ -98,7 +98,7 @@ func loadbalancerClusterUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <cluster: id>...",
 		Short:   "Updates a cluster",
 		Long:    "This command updates one or more clusters",
-		Example: "ukfast loadbalancer cluster update 123 --name mycluster",
+		Example: "ans loadbalancer cluster update 123 --name mycluster",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing cluster")
@@ -152,7 +152,7 @@ func loadbalancerClusterDeployCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "deploy <cluster: id>...",
 		Short:   "Deploys a cluster",
 		Long:    "This command deploys one or more clusters",
-		Example: "ukfast loadbalancer cluster deploy 123",
+		Example: "ans loadbalancer cluster deploy 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing cluster")
@@ -187,7 +187,7 @@ func loadbalancerClusterValidateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "validate <cluster: id>...",
 		Short:   "Validates a cluster",
 		Long:    "This command validates one or more clusters",
-		Example: "ukfast loadbalancer cluster validate 123",
+		Example: "ans loadbalancer cluster validate 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing cluster")

--- a/cmd/loadbalancer/loadbalancer_cluster_acltemplate.go
+++ b/cmd/loadbalancer/loadbalancer_cluster_acltemplate.go
@@ -28,7 +28,7 @@ func loadbalancerClusterACLTemplateShowCmd(f factory.ClientFactory) *cobra.Comma
 		Use:     "show <cluster: id>",
 		Short:   "Shows ACL templates",
 		Long:    "This command shows ACL templates",
-		Example: "ukfast loadbalancer cluster acltemplate show 123",
+		Example: "ans loadbalancer cluster acltemplate show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing cluster")

--- a/cmd/loadbalancer/loadbalancer_listener.go
+++ b/cmd/loadbalancer/loadbalancer_listener.go
@@ -40,7 +40,7 @@ func loadbalancerListenerListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists listeners",
 		Long:    "This command lists listeners",
-		Example: "ukfast loadbalancer listener list",
+		Example: "ans loadbalancer listener list",
 		RunE:    loadbalancerCobraRunEFunc(f, loadbalancerListenerList),
 	}
 }
@@ -64,7 +64,7 @@ func loadbalancerListenerShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <listener: id>...",
 		Short:   "Shows a listener",
 		Long:    "This command shows one or more listeners",
-		Example: "ukfast loadbalancer listener show 123",
+		Example: "ans loadbalancer listener show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing listener")
@@ -102,7 +102,7 @@ func loadbalancerListenerCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <listener: id>",
 		Short:   "Creates a listener",
 		Long:    "This command creates a listener",
-		Example: "ukfast loadbalancer listener create --cluster 123 --default-target-group 456 --name \"test-listener\" --mode http",
+		Example: "ans loadbalancer listener create --cluster 123 --default-target-group 456 --name \"test-listener\" --mode http",
 		RunE:    loadbalancerCobraRunEFunc(f, loadbalancerListenerCreate),
 	}
 
@@ -169,7 +169,7 @@ func loadbalancerListenerUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <listener: id>...",
 		Short:   "Updates a listener",
 		Long:    "This command updates one or more listeners",
-		Example: "ukfast loadbalancer listener update 123 --name mylistener",
+		Example: "ans loadbalancer listener update 123 --name mylistener",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing listener")
@@ -243,7 +243,7 @@ func loadbalancerListenerDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <listener: id>...",
 		Short:   "Removes a listener",
 		Long:    "This command removes one or more listeners",
-		Example: "ukfast loadbalancer listener delete 123",
+		Example: "ans loadbalancer listener delete 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing listener")

--- a/cmd/loadbalancer/loadbalancer_listener_accessip.go
+++ b/cmd/loadbalancer/loadbalancer_listener_accessip.go
@@ -31,7 +31,7 @@ func loadbalancerListenerAccessIPListCmd(f factory.ClientFactory) *cobra.Command
 		Use:     "list <listener: id>",
 		Short:   "Lists access IPs",
 		Long:    "This command lists access IPs",
-		Example: "ukfast loadbalancer listener accessip list 123",
+		Example: "ans loadbalancer listener accessip list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing listener")
@@ -67,7 +67,7 @@ func loadbalancerListenerAccessIPCreateCmd(f factory.ClientFactory) *cobra.Comma
 		Use:     "create <listener: id>",
 		Short:   "Creates an access IP",
 		Long:    "This command creates an access IP",
-		Example: "ukfast loadbalancer listener accessip create 123 --ip 1.2.3.4",
+		Example: "ans loadbalancer listener accessip create 123 --ip 1.2.3.4",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing listener")

--- a/cmd/loadbalancer/loadbalancer_listener_acl.go
+++ b/cmd/loadbalancer/loadbalancer_listener_acl.go
@@ -29,7 +29,7 @@ func loadbalancerListenerACLListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <listener: id>",
 		Short:   "Lists ACLs",
 		Long:    "This command lists ACLs",
-		Example: "ukfast loadbalancer listener acl list 123",
+		Example: "ans loadbalancer listener acl list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing listener")

--- a/cmd/loadbalancer/loadbalancer_listener_bind.go
+++ b/cmd/loadbalancer/loadbalancer_listener_bind.go
@@ -33,7 +33,7 @@ func loadbalancerListenerBindListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <listener: id>",
 		Short:   "Lists binds",
 		Long:    "This command lists binds",
-		Example: "ukfast loadbalancer listener bind list 123",
+		Example: "ans loadbalancer listener bind list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing listener")
@@ -69,7 +69,7 @@ func loadbalancerListenerBindShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <listener: id> <bind: id>...",
 		Short:   "Shows a bind",
 		Long:    "This command shows one or more binds",
-		Example: "ukfast loadbalancer listener bind show 123 345",
+		Example: "ans loadbalancer listener bind show 123 345",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing listener")
@@ -116,7 +116,7 @@ func loadbalancerListenerBindCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <listener: id>",
 		Short:   "Creates a bind",
 		Long:    "This command creates a bind",
-		Example: "ukfast loadbalancer listener bind create 123 --vip 456 --port 443",
+		Example: "ans loadbalancer listener bind create 123 --vip 456 --port 443",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing listener")
@@ -163,7 +163,7 @@ func loadbalancerListenerBindUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <listener: id> <bind: id>...",
 		Short:   "Updates a bind",
 		Long:    "This command updates one or more binds",
-		Example: "ukfast loadbalancer listener bind update 123 456 --port 443",
+		Example: "ans loadbalancer listener bind update 123 456 --port 443",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing listener")
@@ -224,7 +224,7 @@ func loadbalancerListenerBindDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <listener: id> <bind: id>...",
 		Short:   "Removes a bind",
 		Long:    "This command removes one or more binds",
-		Example: "ukfast loadbalancer listener bind delete 123 456",
+		Example: "ans loadbalancer listener bind delete 123 456",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing listener")

--- a/cmd/loadbalancer/loadbalancer_listener_certificate.go
+++ b/cmd/loadbalancer/loadbalancer_listener_certificate.go
@@ -34,7 +34,7 @@ func loadbalancerListenerCertificateListCmd(f factory.ClientFactory) *cobra.Comm
 		Use:     "list <listener: id>",
 		Short:   "Lists certificates",
 		Long:    "This command lists certificates",
-		Example: "ukfast loadbalancer listener certificate list 123",
+		Example: "ans loadbalancer listener certificate list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing listener")
@@ -70,7 +70,7 @@ func loadbalancerListenerCertificateShowCmd(f factory.ClientFactory) *cobra.Comm
 		Use:     "show <listener: id> <certificate: id>...",
 		Short:   "Shows a certificate",
 		Long:    "This command shows one or more certificates",
-		Example: "ukfast loadbalancer listener certificate show 123 345",
+		Example: "ans loadbalancer listener certificate show 123 345",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing listener")
@@ -117,7 +117,7 @@ func loadbalancerListenerCertificateCreateCmd(f factory.ClientFactory, fs afero.
 		Use:     "create <listener: id>",
 		Short:   "Creates a certificate",
 		Long:    "This command creates a certificate",
-		Example: "ukfast loadbalancer listener certificate create 123 --key-file /tmp/cert.key --certificate-file /tmp/cert.crt --ca-bundle-file /tmp/ca.crt",
+		Example: "ans loadbalancer listener certificate create 123 --key-file /tmp/cert.key --certificate-file /tmp/cert.crt --ca-bundle-file /tmp/ca.crt",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing listener")
@@ -185,7 +185,7 @@ func loadbalancerListenerCertificateUpdateCmd(f factory.ClientFactory, fs afero.
 		Use:     "update <listener: id> <certificate: id>...",
 		Short:   "Updates a certificate",
 		Long:    "This command updates one or more certificates",
-		Example: "ukfast loadbalancer listener certificate update 123 456 --name mycertificate",
+		Example: "ans loadbalancer listener certificate update 123 456 --name mycertificate",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing listener")
@@ -269,7 +269,7 @@ func loadbalancerListenerCertificateDeleteCmd(f factory.ClientFactory) *cobra.Co
 		Use:     "delete <listener: id> <certificate: id>...",
 		Short:   "Removes a certificate",
 		Long:    "This command removes one or more certificates",
-		Example: "ukfast loadbalancer listener certificate delete 123 456",
+		Example: "ans loadbalancer listener certificate delete 123 456",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing listener")

--- a/cmd/loadbalancer/loadbalancer_targetgroup.go
+++ b/cmd/loadbalancer/loadbalancer_targetgroup.go
@@ -38,7 +38,7 @@ func loadbalancerTargetGroupListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists target groups",
 		Long:    "This command lists target groups",
-		Example: "ukfast loadbalancer targetgroup list",
+		Example: "ans loadbalancer targetgroup list",
 		RunE:    loadbalancerCobraRunEFunc(f, loadbalancerTargetGroupList),
 	}
 }
@@ -62,7 +62,7 @@ func loadbalancerTargetGroupShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <targetgroup: id>...",
 		Short:   "Shows a target group",
 		Long:    "This command shows one or more target groups",
-		Example: "ukfast loadbalancer targetgroup show 123",
+		Example: "ans loadbalancer targetgroup show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing target group")
@@ -100,7 +100,7 @@ func loadbalancerTargetGroupCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <targetgroup: id>",
 		Short:   "Creates a target group",
 		Long:    "This command creates a target group",
-		Example: "ukfast loadbalancer targetgroup create --cluster 123 --name \"test-targetgroup\" --balance roundrobin --mode http",
+		Example: "ans loadbalancer targetgroup create --cluster 123 --name \"test-targetgroup\" --balance roundrobin --mode http",
 		RunE:    loadbalancerCobraRunEFunc(f, loadbalancerTargetGroupCreate),
 	}
 
@@ -199,7 +199,7 @@ func loadbalancerTargetGroupUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <targetgroup: id>...",
 		Short:   "Updates a target group",
 		Long:    "This command updates one or more target groups",
-		Example: "ukfast loadbalancer targetgroup update 123 --name mytargetgroup",
+		Example: "ans loadbalancer targetgroup update 123 --name mytargetgroup",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing target group")
@@ -315,7 +315,7 @@ func loadbalancerTargetGroupDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <targetgroup: id>...",
 		Short:   "Removes a target group",
 		Long:    "This command removes one or more target groups",
-		Example: "ukfast loadbalancer targetgroup delete 123",
+		Example: "ans loadbalancer targetgroup delete 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing target group")

--- a/cmd/loadbalancer/loadbalancer_targetgroup_acl.go
+++ b/cmd/loadbalancer/loadbalancer_targetgroup_acl.go
@@ -29,7 +29,7 @@ func loadbalancerTargetGroupACLListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <acl: id>",
 		Short:   "Lists ACLs",
 		Long:    "This command lists ACLs",
-		Example: "ukfast loadbalancer targetgroup acl list 123",
+		Example: "ans loadbalancer targetgroup acl list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing target group")

--- a/cmd/loadbalancer/loadbalancer_targetgroup_target.go
+++ b/cmd/loadbalancer/loadbalancer_targetgroup_target.go
@@ -34,7 +34,7 @@ func loadbalancerTargetGroupTargetListCmd(f factory.ClientFactory) *cobra.Comman
 		Use:     "list <targetgroup: id>",
 		Short:   "Lists targets",
 		Long:    "This command lists targets",
-		Example: "ukfast loadbalancer targetgroup target list 123",
+		Example: "ans loadbalancer targetgroup target list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing target group")
@@ -70,7 +70,7 @@ func loadbalancerTargetGroupTargetShowCmd(f factory.ClientFactory) *cobra.Comman
 		Use:     "show <targetgroup: id> <target: id>...",
 		Short:   "Shows a target",
 		Long:    "This command shows one or more targets",
-		Example: "ukfast loadbalancer targetgroup target show 123 345",
+		Example: "ans loadbalancer targetgroup target show 123 345",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing target group")
@@ -117,7 +117,7 @@ func loadbalancerTargetGroupTargetCreateCmd(f factory.ClientFactory) *cobra.Comm
 		Use:     "create <targetgroup: id>",
 		Short:   "Creates a target",
 		Long:    "This command creates a target",
-		Example: "ukfast loadbalancer targetgroup target create 123 --ip 1.2.3.4 --port 443",
+		Example: "ans loadbalancer targetgroup target create 123 --ip 1.2.3.4 --port 443",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing target group")
@@ -184,7 +184,7 @@ func loadbalancerTargetGroupTargetUpdateCmd(f factory.ClientFactory) *cobra.Comm
 		Use:     "update <targetgroup: id> <target: id>...",
 		Short:   "Updates a target",
 		Long:    "This command updates one or more targets",
-		Example: "ukfast loadbalancer targetgroup target update 123 456 --port 443",
+		Example: "ans loadbalancer targetgroup target update 123 456 --port 443",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing target group")
@@ -265,7 +265,7 @@ func loadbalancerTargetGroupTargetDeleteCmd(f factory.ClientFactory) *cobra.Comm
 		Use:     "delete <targetgroup: id> <target: id>...",
 		Short:   "Removes a target",
 		Long:    "This command removes one or more targets",
-		Example: "ukfast loadbalancer targetgroup target delete 123 456",
+		Example: "ans loadbalancer targetgroup target delete 123 456",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing target group")

--- a/cmd/pss/pss_reply.go
+++ b/cmd/pss/pss_reply.go
@@ -30,7 +30,7 @@ func pssReplyShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <reply: id>...",
 		Short:   "Shows a reply",
 		Long:    "This command shows one or more replies",
-		Example: "ukfast pss reply show 123",
+		Example: "ans pss reply show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing reply")

--- a/cmd/pss/pss_reply_attachment.go
+++ b/cmd/pss/pss_reply_attachment.go
@@ -33,7 +33,7 @@ func pssReplyAttachmentDownloadCmd(f factory.ClientFactory, fs afero.Fs) *cobra.
 		Use:     "download <reply: id> <attachment: name>",
 		Short:   "Downloads a reply attachment",
 		Long:    "This command downloads a reply attachment",
-		Example: "ukfast pss reply attachment download 123 file.txt --path /path/to/file",
+		Example: "ans pss reply attachment download 123 file.txt --path /path/to/file",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing reply")
@@ -89,7 +89,7 @@ func pssReplyAttachmentUploadCmd(f factory.ClientFactory, fs afero.Fs) *cobra.Co
 		Use:     "upload <reply: id>",
 		Short:   "Uploads a reply attachment",
 		Long:    "This command uploads a reply attachment",
-		Example: "ukfast pss reply attachment upload 123 --path /path/to/file",
+		Example: "ans pss reply attachment upload 123 --path /path/to/file",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing reply")
@@ -134,7 +134,7 @@ func pssReplyAttachmentDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <reply: id> <attachment: name>...",
 		Short:   "Deletes a reply attachment",
 		Long:    "This command deletes one or more reply attachments",
-		Example: "ukfast pss reply attachment delete 123 file.txt",
+		Example: "ans pss reply attachment delete 123 file.txt",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing reply")

--- a/cmd/pss/pss_request.go
+++ b/cmd/pss/pss_request.go
@@ -38,7 +38,7 @@ func pssRequestListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists requests",
 		Long:    "This command lists requests",
-		Example: "ukfast pss request list",
+		Example: "ans pss request list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -69,7 +69,7 @@ func pssRequestShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <request: id>...",
 		Short:   "Shows a request",
 		Long:    "This command shows one or more requests",
-		Example: "ukfast pss request show 123",
+		Example: "ans pss request show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing request")
@@ -114,7 +114,7 @@ func pssRequestCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a request",
 		Long:    "This command creates a new request",
-		Example: "ukfast pss request create --subject 'example ticket' --details 'example' --author 123",
+		Example: "ans pss request create --subject 'example ticket' --details 'example' --author 123",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -194,7 +194,7 @@ func pssRequestUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <request: id>...",
 		Short:   "Updates requests",
 		Long:    "This command updates one or more requests",
-		Example: "ukfast pss request update 123 --priority high",
+		Example: "ans pss request update 123 --priority high",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing request")
@@ -293,7 +293,7 @@ func pssRequestCloseCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "close <request: id>...",
 		Short:   "Closes requests",
 		Long:    "This command closes one or more requests",
-		Example: "ukfast pss request close 123",
+		Example: "ans pss request close 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing request")

--- a/cmd/pss/pss_request_feedback.go
+++ b/cmd/pss/pss_request_feedback.go
@@ -29,7 +29,7 @@ func pssRequestFeedbackShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <request: id>...",
 		Short:   "Shows feedback for a request",
 		Long:    "This command shows feedback for one or more requests",
-		Example: "ukfast pss request feedback show 123",
+		Example: "ans pss request feedback show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing request")
@@ -74,7 +74,7 @@ func pssRequestFeedbackCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <request: id>",
 		Short:   "Creates feedback for a request",
 		Long:    "This command creates feedback for a request",
-		Example: "ukfast pss request feedback create 123",
+		Example: "ans pss request feedback create 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing request")

--- a/cmd/pss/pss_request_reply.go
+++ b/cmd/pss/pss_request_reply.go
@@ -33,7 +33,7 @@ func pssRequestReplyListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <request: id>",
 		Short:   "Lists a request",
 		Long:    "This command lists the replies for a request",
-		Example: "ukfast pss request reply list 123",
+		Example: "ans pss request reply list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing request")
@@ -76,7 +76,7 @@ func pssRequestReplyCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a reply",
 		Long:    "This command creates a new reply",
-		Example: "ukfast pss request reply create --description 'example' --author 123",
+		Example: "ans pss request reply create --description 'example' --author 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing request")

--- a/cmd/registrar/registrar_domain.go
+++ b/cmd/registrar/registrar_domain.go
@@ -32,7 +32,7 @@ func registrarDomainListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists domains",
 		Long:    "This command lists domains",
-		Example: "ukfast registrar domain list",
+		Example: "ans registrar domain list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -63,7 +63,7 @@ func registrarDomainShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <domain: name>...",
 		Short:   "Shows a domain",
 		Long:    "This command shows one or more domains",
-		Example: "ukfast registrar domain show example.com",
+		Example: "ans registrar domain show example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/registrar/registrar_domain_nameserver.go
+++ b/cmd/registrar/registrar_domain_nameserver.go
@@ -27,7 +27,7 @@ func registrarDomainNameserverListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists domain nameservers",
 		Long:    "This command lists a domain's nameservers",
-		Example: "ukfast registrar domain nameserver list example.com",
+		Example: "ans registrar domain nameserver list example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/registrar/registrar_whois.go
+++ b/cmd/registrar/registrar_whois.go
@@ -27,7 +27,7 @@ func registrarWhoisShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <domain: name>...",
 		Short:   "Shows whois for a domain",
 		Long:    "This command shows whois for one or more domains",
-		Example: "ukfast registrar whois show example.com",
+		Example: "ans registrar whois show example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ var appVersion string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:     "ukfast",
+	Use:     "ans",
 	Short:   "Utility for manipulating UKFast services",
 	Version: "UNKNOWN",
 }
@@ -42,7 +42,7 @@ func Execute(build build.BuildInfo) {
 	rootCmd.SilenceUsage = true
 
 	// Global flags
-	rootCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.ukfast.yml)")
+	rootCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.ans.yml)")
 	rootCmd.PersistentFlags().String("context", "", "specific context to use")
 	rootCmd.PersistentFlags().StringP("output", "o", "", "output type {table, json, yaml, jsonpath, template, value, csv, list}, with optional argument provided as 'outputname=outputargument'")
 	rootCmd.PersistentFlags().StringP("format", "f", "", "")
@@ -57,7 +57,7 @@ func Execute(build build.BuildInfo) {
 	cobra.OnInitialize(initConfig)
 	fs := afero.NewOsFs()
 	clientFactory := factory.NewUKFastClientFactory(
-		factory.WithUserAgent("ukfast-cli"),
+		factory.WithUserAgent("ans-cli"),
 	)
 
 	// Child commands

--- a/cmd/safedns/safedns_settings.go
+++ b/cmd/safedns/safedns_settings.go
@@ -26,7 +26,7 @@ func safednsSettingsShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show",
 		Short:   "Shows settings for account",
 		Long:    "This command shows SafeDNS settings for account",
-		Example: "ukfast safedns settings show",
+		Example: "ans safedns settings show",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {

--- a/cmd/safedns/safedns_template.go
+++ b/cmd/safedns/safedns_template.go
@@ -36,7 +36,7 @@ func safednsTemplateListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists templates",
 		Long:    "This command lists templates",
-		Example: "ukfast safedns template list",
+		Example: "ans safedns template list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -72,7 +72,7 @@ func safednsTemplateShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <template: name/id>...",
 		Short:   "Shows a template",
 		Long:    "This command shows one or more templates",
-		Example: "ukfast safedns template show \"main template\"",
+		Example: "ans safedns template show \"main template\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing template")
@@ -111,7 +111,7 @@ func safednsTemplateCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a template",
 		Long:    "This command creates a template",
-		Example: "ukfast safedns template create --name \"main template\"",
+		Example: "ans safedns template create --name \"main template\"",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -155,7 +155,7 @@ func safednsTemplateUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <template: name/id>...",
 		Short:   "Updates a template",
 		Long:    "This command updates one or more templates",
-		Example: "ukfast safedns template update \"main template\" --name \"old template\"",
+		Example: "ans safedns template update \"main template\" --name \"old template\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing template")
@@ -223,7 +223,7 @@ func safednsTemplateDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <template: name/id>...",
 		Short:   "Removes a template",
 		Long:    "This command removes one or more templates",
-		Example: "ukfast safedns template delete \"main template\"",
+		Example: "ans safedns template delete \"main template\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing template")

--- a/cmd/safedns/safedns_template_record.go
+++ b/cmd/safedns/safedns_template_record.go
@@ -34,7 +34,7 @@ func safednsTemplateRecordListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <template: id/name>",
 		Short:   "Lists template records",
 		Long:    "This command lists template records",
-		Example: "ukfast safedns template record list \"main template\"\nukfast safedns template record list 123",
+		Example: "ans safedns template record list \"main template\"\nans safedns template record list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing template")
@@ -86,7 +86,7 @@ func safednsTemplateRecordShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <template: id/name> <record: id>...",
 		Short:   "Shows a template record",
 		Long:    "This command shows one or more template records",
-		Example: "ukfast safedns template record show \"main template\" 123",
+		Example: "ans safedns template record show \"main template\" 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing template")
@@ -140,7 +140,7 @@ func safednsTemplateRecordCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <template: id/name>",
 		Short:   "Creates a template record",
 		Long:    "This command creates a template record",
-		Example: "ukfast safedns template record create \"main template\" --name subdomain.ukfast.co.uk --type A --content 1.2.3.4",
+		Example: "ans safedns template record create \"main template\" --name subdomain.ans.co.uk --type A --content 1.2.3.4",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing template")
@@ -216,7 +216,7 @@ func safednsTemplateRecordUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <template: id/name> <record: id>...",
 		Short:   "Updates a template record",
 		Long:    "This command updates one or more template records",
-		Example: "ukfast safedns template record update \"main template\" 123 --content 1.2.3.4",
+		Example: "ans safedns template record update \"main template\" 123 --content 1.2.3.4",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing template")
@@ -308,7 +308,7 @@ func safednsTemplateRecordDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <template: id/name> <record: id>...",
 		Short:   "Removes a template record",
 		Long:    "This command deletes one or more template records",
-		Example: "ukfast safedns template record delete \"main template\" 123",
+		Example: "ans safedns template record delete \"main template\" 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing template")

--- a/cmd/safedns/safedns_zone.go
+++ b/cmd/safedns/safedns_zone.go
@@ -35,7 +35,7 @@ func safednsZoneListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists zones",
 		Long:    "This command lists zones",
-		Example: "ukfast safedns zone list",
+		Example: "ans safedns zone list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -70,7 +70,7 @@ func safednsZoneShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <zone: name>...",
 		Short:   "Shows a zone",
 		Long:    "This command shows one or more zones",
-		Example: "ukfast safedns zone show ukfast.co.uk\nukfast safedns zone show 123",
+		Example: "ans safedns zone show ans.co.uk\nans safedns zone show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing zone")
@@ -109,7 +109,7 @@ func safednsZoneCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create",
 		Short:   "Creates a zone",
 		Long:    "This command creates a zone",
-		Example: "ukfast safedns zone create",
+		Example: "ans safedns zone create",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -155,7 +155,7 @@ func safednsZoneUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <zone: name>...",
 		Short:   "Updates a zone",
 		Long:    "This command updates one or more zones",
-		Example: "ukfast safedns zone update ukfast.co.uk --description \"some description\"",
+		Example: "ans safedns zone update ans.co.uk --description \"some description\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing zone")
@@ -207,7 +207,7 @@ func safednsZoneDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <zone: name>...",
 		Short:   "Removes a zone",
 		Long:    "This command removes one or more zones",
-		Example: "ukfast safedns zone delete ukfast.co.uk\nukfast safedns zone delete 123",
+		Example: "ans safedns zone delete ans.co.uk\nans safedns zone delete 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing zone")

--- a/cmd/safedns/safedns_zone_note.go
+++ b/cmd/safedns/safedns_zone_note.go
@@ -31,7 +31,7 @@ func safednsZoneNoteListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <zone: name>",
 		Short:   "Lists zone notes",
 		Long:    "This command lists zone notes",
-		Example: "ukfast safedns zone note list ukfast.co.uk\nukfast safedns zone note list 123",
+		Example: "ans safedns zone note list ans.co.uk\nans safedns zone note list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing zone")
@@ -73,7 +73,7 @@ func safednsZoneNoteShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <zone: name> <note: id>...",
 		Short:   "Shows a zone note",
 		Long:    "This command shows one or more zone notes",
-		Example: "ukfast safedns zone note show ukfast.co.uk 123",
+		Example: "ans safedns zone note show ans.co.uk 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing zone")
@@ -122,7 +122,7 @@ func safednsZoneNoteCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <zone: name>",
 		Short:   "Creates a zone note",
 		Long:    "This command creates a zone note",
-		Example: "ukfast safedns zone note create ukfast.co.uk --notes \"test note\"",
+		Example: "ans safedns zone note create ans.co.uk --notes \"test note\"",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing zone")

--- a/cmd/safedns/safedns_zone_record.go
+++ b/cmd/safedns/safedns_zone_record.go
@@ -35,7 +35,7 @@ func safednsZoneRecordListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list <zone: name>",
 		Short:   "Lists zone records",
 		Long:    "This command lists zone records",
-		Example: "ukfast safedns zone record list ukfast.co.uk\nukfast safedns zone record list 123",
+		Example: "ans safedns zone record list ans.co.uk\nans safedns zone record list 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing zone")
@@ -83,7 +83,7 @@ func safednsZoneRecordShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <zone: name> <record: id>...",
 		Short:   "Shows a zone record",
 		Long:    "This command shows one or more zone records",
-		Example: "ukfast safedns zone record show ukfast.co.uk 123",
+		Example: "ans safedns zone record show ans.co.uk 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing zone")
@@ -132,7 +132,7 @@ func safednsZoneRecordCreateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "create <zone: name>",
 		Short:   "Creates a zone record",
 		Long:    "This command creates a zone record",
-		Example: "ukfast safedns zone record create ukfast.co.uk --name subdomain.ukfast.co.uk --type A --content 1.2.3.4",
+		Example: "ans safedns zone record create ans.co.uk --name subdomain.ans.co.uk --type A --content 1.2.3.4",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing zone")
@@ -200,7 +200,7 @@ func safednsZoneRecordUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <zone: name> <record: id>...",
 		Short:   "Updates a zone record",
 		Long:    "This command updates one or more zone records",
-		Example: "ukfast safedns zone record update ukfast.co.uk 123 --content 1.2.3.4",
+		Example: "ans safedns zone record update ans.co.uk 123 --content 1.2.3.4",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing zone")
@@ -280,7 +280,7 @@ func safednsZoneRecordDeleteCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "delete <zone: name> <record: id>...",
 		Short:   "Removes a zone record",
 		Long:    "This command deletes one or more zone records",
-		Example: "ukfast safedns zone record delete ukfast.co.uk 123",
+		Example: "ans safedns zone record delete ans.co.uk 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing zone")

--- a/cmd/sharedexchange/sharedexchange_domain.go
+++ b/cmd/sharedexchange/sharedexchange_domain.go
@@ -30,7 +30,7 @@ func sharedexchangeDomainListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists domains",
 		Long:    "This command lists domains",
-		Example: "ukfast sharedexchange domain list",
+		Example: "ans sharedexchange domain list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -61,7 +61,7 @@ func sharedexchangeDomainShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <domain: id>...",
 		Short:   "Shows a domain",
 		Long:    "This command shows one or more domains",
-		Example: "ukfast sharedexchange domain show 123",
+		Example: "ans sharedexchange domain show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ssl/ssl.go
+++ b/cmd/ssl/ssl.go
@@ -33,7 +33,7 @@ func sslValidateCmd(f factory.ClientFactory, fs afero.Fs) *cobra.Command {
 		Use:     "validate",
 		Short:   "Validates a certificate",
 		Long:    "This command validates an SSL certificate",
-		Example: "ukfast ssl validate --certificate-file /tmp/cert.crt --key-file /tmp/cert.key --ca-bundle-file /tmp/ca.crt",
+		Example: "ans ssl validate --certificate-file /tmp/cert.crt --key-file /tmp/cert.key --ca-bundle-file /tmp/ca.crt",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {

--- a/cmd/ssl/ssl_certificate.go
+++ b/cmd/ssl/ssl_certificate.go
@@ -34,7 +34,7 @@ func sslCertificateListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists certificates",
 		Long:    "This command lists certificates",
-		Example: "ukfast ssl certificate list",
+		Example: "ans ssl certificate list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -65,7 +65,7 @@ func sslCertificateShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <certificate: id>...",
 		Short:   "Shows a certificate",
 		Long:    "This command shows one or more certificates",
-		Example: "ukfast ssl certificate show 123",
+		Example: "ans ssl certificate show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing certificate")

--- a/cmd/ssl/ssl_certificate_content.go
+++ b/cmd/ssl/ssl_certificate_content.go
@@ -28,7 +28,7 @@ func sslCertificateContentShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <certificate: id>...",
 		Short:   "Shows a certificate content",
 		Long:    "This command shows one or more certificate contents",
-		Example: "ukfast ssl certificate content show 123",
+		Example: "ans ssl certificate content show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing certificate")

--- a/cmd/ssl/ssl_certificate_privatekey.go
+++ b/cmd/ssl/ssl_certificate_privatekey.go
@@ -27,7 +27,7 @@ func sslCertificatePrivateKeyShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <certificate: id>...",
 		Short:   "Shows a certificate private key",
 		Long:    "This command shows one or more certificate private keys",
-		Example: "ukfast ssl certificate privatekey show 123",
+		Example: "ans ssl certificate privatekey show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing certificate")

--- a/cmd/ssl/ssl_recommendations.go
+++ b/cmd/ssl/ssl_recommendations.go
@@ -26,7 +26,7 @@ func sslRecommendationsShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <recommendations: id>...",
 		Short:   "Shows SSL recommendations",
 		Long:    "This command shows one or more SSL recommendations",
-		Example: "ukfast ssl recommendations show example.com",
+		Example: "ans ssl recommendations show example.com",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/ssl/ssl_report.go
+++ b/cmd/ssl/ssl_report.go
@@ -26,7 +26,7 @@ func sslReportShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <report: id>...",
 		Short:   "Shows a report",
 		Long:    "This command shows one or more reports",
-		Example: "ukfast ssl report show 123",
+		Example: "ans ssl report show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing domain")

--- a/cmd/storage/storage_host.go
+++ b/cmd/storage/storage_host.go
@@ -30,7 +30,7 @@ func storageHostListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists hosts",
 		Long:    "This command lists hosts",
-		Example: "ukfast storage host list",
+		Example: "ans storage host list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -61,7 +61,7 @@ func storageHostShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <host: id>...",
 		Short:   "Shows a host",
 		Long:    "This command shows one or more hosts",
-		Example: "ukfast storage host show 123",
+		Example: "ans storage host show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing host")

--- a/cmd/storage/storage_solution.go
+++ b/cmd/storage/storage_solution.go
@@ -30,7 +30,7 @@ func storageSolutionListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists solutions",
 		Long:    "This command lists solutions",
-		Example: "ukfast storage solution list",
+		Example: "ans storage solution list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -61,7 +61,7 @@ func storageSolutionShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <solution: id>...",
 		Short:   "Shows a solution",
 		Long:    "This command shows one or more solutions",
-		Example: "ukfast storage solution show 123",
+		Example: "ans storage solution show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing solution")

--- a/cmd/storage/storage_volume.go
+++ b/cmd/storage/storage_volume.go
@@ -30,7 +30,7 @@ func storageVolumeListCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "list",
 		Short:   "Lists volumes",
 		Long:    "This command lists volumes",
-		Example: "ukfast storage volume list",
+		Example: "ans storage volume list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := f.NewClient()
 			if err != nil {
@@ -61,7 +61,7 @@ func storageVolumeShowCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "show <volume: id>...",
 		Short:   "Shows a volume",
 		Long:    "This command shows one or more volumes",
-		Example: "ukfast storage volume show 123",
+		Example: "ans storage volume show 123",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing volume")

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -17,15 +17,15 @@ func updateCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("Unable to parse version: %s", err.Error())
 			}
-			newRelease, err := selfupdate.UpdateSelf(currentVersion, "ukfast/cli")
+			newRelease, err := selfupdate.UpdateSelf(currentVersion, "ans-group/cli")
 			if err != nil {
-				return fmt.Errorf("Failed to update UKFast CLI: %s", err.Error())
+				return fmt.Errorf("Failed to update ANS CLI: %s", err.Error())
 			}
 
 			if currentVersion.Equals(newRelease.Version) {
-				fmt.Printf("UKFast CLI already at latest version (%s)\n", appVersion)
+				fmt.Printf("ANS CLI already at latest version (%s)\n", appVersion)
 			} else {
-				fmt.Printf("UKFast CLI updated to version v%s successfully\n", newRelease.Version)
+				fmt.Printf("ANS CLI updated to version v%s successfully\n", newRelease.Version)
 				fmt.Println("Release notes:\n", newRelease.ReleaseNotes)
 			}
 			return nil

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -10,12 +10,12 @@ import (
 )
 
 var defaultConfigFile string
-var configName = ".ukfast"
+var configName = ".ans"
 var initialised bool
 
 // Init initialises the config package
 func Init(configPath string) error {
-	viper.SetEnvPrefix("ukf")
+	viper.SetEnvPrefix("ans")
 	viper.AutomaticEnv()
 
 	if len(configPath) > 0 {
@@ -27,7 +27,7 @@ func Init(configPath string) error {
 			return err
 		}
 
-		// Search config in home directory with name ".ukfast" (without extension)
+		// Search config in home directory with name ".ans" (without extension)
 		viper.AddConfigPath(home)
 		viper.SetConfigName(configName)
 		defaultConfigFile = fmt.Sprintf("%s/%s.yml", home, configName)


### PR DESCRIPTION
* Renames `ukfast` to `ans` where applicable.
* Updates default config file location from `~/.ukfast.{extension}` to `~/.ans.{extension}`
* Updates environment variable prefix from `UKF_` to `ANS_`