### PR TITLE
Config default fix

### DIFF
--- a/cmd/config/config_context_test.go
+++ b/cmd/config/config_context_test.go
@@ -79,6 +79,30 @@ current_context: testcontext1
 	})
 }
 
+func Test_configContextShow(t *testing.T) {
+	t.Run("ShowsCurrentContext", func(t *testing.T) {
+		defer config.Reset()
+		fs := afero.NewMemMapFs()
+		config.SetFs(fs)
+
+		afero.WriteFile(fs, "/tmp/testconfig.yml", []byte(`contexts:
+  testcontext1:
+    api_key: testkey
+  testcontext2:
+    api_key: testkey2
+current_context: testcontext1
+`), 0644)
+		config.Init("/tmp/testconfig.yml")
+
+		cmd := configContextShowCmd()
+		cmd.Flags().String("output", "value", "")
+
+		test_output.AssertCombinedOutput(t, "testcontext1 true\n", "", func() {
+			configContextShow(cmd)
+		})
+	})
+}
+
 func Test_configContextSwitchCmd_Args(t *testing.T) {
 	t.Run("ValidArgs_NoError", func(t *testing.T) {
 		err := configContextSwitchCmd(nil).Args(nil, []string{"testcontext"})

--- a/cmd/config/output.go
+++ b/cmd/config/output.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"strconv"
+
+	"github.com/ans-group/cli/internal/pkg/output"
+)
+
+type Context struct {
+	Name   string `json:"name"`
+	Active bool   `json:"active"`
+}
+
+func OutputConfigContextsProvider(contexts []Context) output.OutputHandlerDataProvider {
+	return output.NewGenericOutputHandlerDataProvider(
+		output.WithData(contexts),
+		output.WithFieldDataFunc(func() ([]*output.OrderedFields, error) {
+			var data []*output.OrderedFields
+			for _, context := range contexts {
+				fields := output.NewOrderedFields()
+				fields.Set("name", output.NewFieldValue(context.Name, true))
+				fields.Set("active", output.NewFieldValue(strconv.FormatBool(context.Active), true))
+
+				data = append(data, fields)
+			}
+
+			return data, nil
+		}),
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ans-group/cli
 go 1.18
 
 require (
-	github.com/ans-group/sdk-go v1.8.0
+	github.com/ans-group/sdk-go v1.8.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/golang/mock v1.6.0
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ans-group/go-durationstring v1.2.0 h1:UJIuQATkp0t1rBvZsHRwki33YHV9E+Ulro+3NbMB7MM=
 github.com/ans-group/go-durationstring v1.2.0/go.mod h1:QGF9Mdpq9058QXaut8r55QWu6lcHX6i/GvF1PZVkV6o=
-github.com/ans-group/sdk-go v1.8.0 h1:qXps4vUuraiWr2IhRn7HN9LFmZOdevgBYe4xhVVCuXM=
-github.com/ans-group/sdk-go v1.8.0/go.mod h1:XSKXEDfKobnDtZoyia5DhJxxaDMcCjr76e1KJ9dU/xc=
+github.com/ans-group/sdk-go v1.8.1 h1:PHPcYHujevWvCMiI7ujXvvrYHf5zpHIcZw7FfJ1rXw0=
+github.com/ans-group/sdk-go v1.8.1/go.mod h1:XSKXEDfKobnDtZoyia5DhJxxaDMcCjr76e1KJ9dU/xc=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -78,13 +78,24 @@ func GetContextNames() []string {
 	return contextNames
 }
 
-func getCurrentContextKeyOrDefault(key string) string {
-	return getContextKeyOrDefault(GetCurrentContextName(), key)
-}
-
 func getContextKeyOrDefault(contextName string, key string) string {
 	if len(contextName) > 0 {
 		return getContextSubKey(contextName, key)
+	}
+
+	return key
+}
+
+func getCurrentContextKeyIfSetOrDefault(key string) string {
+	return getContextKeyIfSetOrDefault(GetCurrentContextName(), key)
+}
+
+func getContextKeyIfSetOrDefault(contextName string, key string) string {
+	if len(contextName) > 0 {
+		contextSubKey := getContextSubKey(contextName, key)
+		if viper.IsSet(contextSubKey) {
+			return contextSubKey
+		}
 	}
 
 	return key
@@ -138,17 +149,17 @@ func Reset() {
 }
 
 func GetString(key string) string {
-	return viper.GetString(getCurrentContextKeyOrDefault(key))
+	return viper.GetString(getCurrentContextKeyIfSetOrDefault(key))
 }
 
 func GetInt(key string) int {
-	return viper.GetInt(getCurrentContextKeyOrDefault(key))
+	return viper.GetInt(getCurrentContextKeyIfSetOrDefault(key))
 }
 
 func GetBool(key string) bool {
-	return viper.GetBool(getCurrentContextKeyOrDefault(key))
+	return viper.GetBool(getCurrentContextKeyIfSetOrDefault(key))
 }
 
 func GetStringMapString(key string) map[string]string {
-	return viper.GetStringMapString(getCurrentContextKeyOrDefault(key))
+	return viper.GetStringMapString(getCurrentContextKeyIfSetOrDefault(key))
 }

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -203,3 +203,51 @@ func TestSwitchCurrentContext(t *testing.T) {
 
 	assert.Equal(t, "testcontext2", currentContext)
 }
+
+func TestGet(t *testing.T) {
+	t.Run("GetsContextValueWhenExists", func(t *testing.T) {
+		defer Reset()
+		fs := afero.NewMemMapFs()
+		SetFs(fs)
+
+		var config = `contexts:
+  testcontext1:
+    somekey: somevalue1
+  testcontext2:
+    somekey: somevalue2
+current_context: testcontext1
+somekey: someothervalue
+`
+
+		afero.WriteFile(fs, "/tmp/testconfig.yml", []byte(config), 0644)
+
+		Init("/tmp/testconfig.yml")
+
+		value := GetString("somekey")
+
+		assert.Equal(t, "somevalue1", value)
+	})
+
+	t.Run("GetsDefaultValueWhenNotExistInContext", func(t *testing.T) {
+		defer Reset()
+		fs := afero.NewMemMapFs()
+		SetFs(fs)
+
+		var config = `contexts:
+  testcontext1:
+    somekey: somevalue1
+  testcontext2:
+    somekey: somevalue2
+current_context: testcontext1
+someotherkey: someothervalue
+`
+
+		afero.WriteFile(fs, "/tmp/testconfig.yml", []byte(config), 0644)
+
+		Init("/tmp/testconfig.yml")
+
+		value := GetString("someotherkey")
+
+		assert.Equal(t, "someothervalue", value)
+	})
+}


### PR DESCRIPTION
* Adds `config context show` command
* Updates config logic to fallback to top-level keys when keys aren't defined within a context
* Tidies up context output