### PR TITLE
ACL rework

### DIFF
--- a/cmd/loadbalancer/loadbalancer_acl.go
+++ b/cmd/loadbalancer/loadbalancer_acl.go
@@ -24,6 +24,9 @@ func loadbalancerACLRootCmd(f factory.ClientFactory) *cobra.Command {
 	cmd.AddCommand(loadbalancerACLUpdateCmd(f))
 	cmd.AddCommand(loadbalancerACLDeleteCmd(f))
 
+	// Child root commands
+	cmd.AddCommand(loadbalancerACLConditionRootCmd(f))
+
 	return cmd
 }
 
@@ -79,9 +82,12 @@ func loadbalancerACLCreateCmd(f factory.ClientFactory) *cobra.Command {
 	cmd.Flags().Int("priority", 0, "Priority of ACL")
 	cmd.Flags().Int("listener", 0, "ID of listener")
 	cmd.Flags().Int("target-group", 0, "ID of target group")
-	cmd.Flags().StringArray("condition", []string{}, "Name and arguments of condition. Can be repeated. Array values can be expressed as: somearray[]=somevalue")
-	cmd.Flags().StringArray("action", []string{}, "Name and arguments of action. Can be repeated. Array values can be expressed as: somearray[]=somevalue")
-	cmd.MarkFlagRequired("action")
+	cmd.Flags().String("condition-name", "", "Name of ACL condition")
+	cmd.Flags().StringArray("condition-argument", []string{}, "ACL condition argument. Can be repeated")
+	cmd.Flags().Bool("condition-inverted", false, "Specifies ACL condition should be inverted")
+	cmd.Flags().String("action-name", "", "Name of ACL action")
+	cmd.MarkFlagRequired("action-name")
+	cmd.Flags().StringArray("action-argument", []string{}, "ACL action argument. Can be repeated")
 
 	return cmd
 }
@@ -93,22 +99,43 @@ func loadbalancerACLCreate(service loadbalancer.LoadBalancerService, cmd *cobra.
 	createRequest.ListenerID, _ = cmd.Flags().GetInt("listener")
 	createRequest.TargetGroupID, _ = cmd.Flags().GetInt("target-group")
 
-	if cmd.Flags().Changed("condition") {
-		conditionsFlag, _ := cmd.Flags().GetStringArray("condition")
-		conditions, err := parseACLConditionsFromFlag(conditionsFlag)
-		if err != nil {
-			return err
+	if cmd.Flags().Changed("condition-name") {
+		condition := loadbalancer.ACLCondition{}
+		condition.Name, _ = cmd.Flags().GetString("condition-name")
+		condition.Inverted, _ = cmd.Flags().GetBool("condition-inverted")
+
+		if cmd.Flags().Changed("condition-argument") {
+			condition.Arguments = make(map[string]loadbalancer.ACLArgument)
+			conditionArguments, _ := cmd.Flags().GetStringArray("condition-argument")
+			conditionArgumentsParsed, err := parseACLArguments(conditionArguments)
+			if err != nil {
+				return fmt.Errorf("Failed to parse arguments: %s", err)
+			}
+
+			condition.Arguments = conditionArgumentsParsed
 		}
-		createRequest.Conditions = conditions
+
+		createRequest.Conditions = []loadbalancer.ACLCondition{condition}
 	}
 
-	if cmd.Flags().Changed("action") {
-		actionsFlag, _ := cmd.Flags().GetStringArray("action")
-		actions, err := parseACLActionsFromFlag(actionsFlag)
-		if err != nil {
-			return err
+	if cmd.Flags().Changed("action-name") {
+		action := loadbalancer.ACLAction{}
+		action.Name, _ = cmd.Flags().GetString("action-name")
+
+		if cmd.Flags().Changed("action-argument") {
+			action.Arguments = make(map[string]loadbalancer.ACLArgument)
+			actionArguments, _ := cmd.Flags().GetStringArray("action-argument")
+
+			for _, actionArgument := range actionArguments {
+				key, value := parseACLArgumentKV(actionArgument)
+				action.Arguments[key] = loadbalancer.ACLArgument{
+					Name:  key,
+					Value: value,
+				}
+			}
 		}
-		createRequest.Actions = actions
+
+		createRequest.Actions = []loadbalancer.ACLAction{action}
 	}
 
 	aclID, err := service.CreateACL(createRequest)
@@ -129,7 +156,7 @@ func loadbalancerACLUpdateCmd(f factory.ClientFactory) *cobra.Command {
 		Use:     "update <acl: id>...",
 		Short:   "Updates an ACL",
 		Long:    "This command updates one or more ACLs",
-		Example: "ans loadbalancer acl update 123 --name myacl --condition \"header_matches:host=ans.co.uk,accept=application/json\" --action \"redirect:location=developers.ans.co.uk,status=302\"",
+		Example: "ans loadbalancer acl update 123 --name myacl",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Missing ACL")
@@ -142,8 +169,6 @@ func loadbalancerACLUpdateCmd(f factory.ClientFactory) *cobra.Command {
 
 	cmd.Flags().String("name", "", "Name of ACL")
 	cmd.Flags().Int("priority", 0, "Priority of ACL")
-	cmd.Flags().StringArray("condition", []string{}, "Name and arguments of condition. Can be repeated. Array values can be expressed as: somearray[]=somevalue")
-	cmd.Flags().StringArray("action", []string{}, "Name and arguments of action. Can be repeated. Array values can be expressed as: somearray[]=somevalue")
 
 	return cmd
 }
@@ -152,24 +177,6 @@ func loadbalancerACLUpdate(service loadbalancer.LoadBalancerService, cmd *cobra.
 	patchRequest := loadbalancer.PatchACLRequest{}
 	patchRequest.Name, _ = cmd.Flags().GetString("name")
 	patchRequest.Priority, _ = cmd.Flags().GetInt("priority")
-
-	if cmd.Flags().Changed("condition") {
-		conditionsFlag, _ := cmd.Flags().GetStringArray("condition")
-		conditions, err := parseACLConditionsFromFlag(conditionsFlag)
-		if err != nil {
-			return err
-		}
-		patchRequest.Conditions = conditions
-	}
-
-	if cmd.Flags().Changed("action") {
-		actionsFlag, _ := cmd.Flags().GetStringArray("action")
-		actions, err := parseACLActionsFromFlag(actionsFlag)
-		if err != nil {
-			return err
-		}
-		patchRequest.Actions = actions
-	}
 
 	var acls []loadbalancer.ACL
 	for _, arg := range args {
@@ -232,53 +239,6 @@ func loadbalancerACLDelete(service loadbalancer.LoadBalancerService, cmd *cobra.
 	return nil
 }
 
-func parseACLActionsFromFlag(actionFlags []string) ([]loadbalancer.ACLAction, error) {
-	var actions []loadbalancer.ACLAction
-	for _, actionFlag := range actionFlags {
-		name, arguments, err := parseACLStatementFlag(actionFlag)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to parse ACL action from flag: %s", err)
-		}
-		actions = append(actions, loadbalancer.ACLAction{
-			Name:      name,
-			Arguments: arguments,
-		})
-	}
-
-	return actions, nil
-}
-
-func parseACLConditionsFromFlag(conditionFlags []string) ([]loadbalancer.ACLCondition, error) {
-	var conditions []loadbalancer.ACLCondition
-	for _, conditionFlag := range conditionFlags {
-		name, arguments, err := parseACLStatementFlag(conditionFlag)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to parse ACL condition from flag: %s", err)
-		}
-		conditions = append(conditions, loadbalancer.ACLCondition{
-			Name:      name,
-			Arguments: arguments,
-		})
-	}
-
-	return conditions, nil
-}
-
-func parseACLStatementFlag(flag string) (string, map[string]loadbalancer.ACLArgument, error) {
-	flagNameSplit := strings.SplitN(flag, ":", 2)
-	if len(flagNameSplit) != 2 {
-		return "", nil, fmt.Errorf("Invalid flag format. Expected format name:arguments")
-	}
-
-	flagArgsSplit := strings.Split(flagNameSplit[1], ",")
-	arguments, err := parseACLArguments(flagArgsSplit)
-	if err != nil {
-		return "", nil, fmt.Errorf("Invalid flag arguments format: %s", err)
-	}
-
-	return flagNameSplit[0], arguments, nil
-}
-
 type aclArgument struct {
 	Name  string
 	Value interface{}
@@ -333,4 +293,16 @@ func parseACLArguments(args []string) (map[string]loadbalancer.ACLArgument, erro
 		}
 	}
 	return arguments, nil
+}
+
+func parseACLArgumentKV(arg string) (string, string) {
+	var value string
+
+	argParts := strings.SplitN(arg, "=", 2)
+
+	if len(argParts) == 2 {
+		value = argParts[1]
+	}
+
+	return argParts[0], value
 }

--- a/cmd/loadbalancer/loadbalancer_acl.go
+++ b/cmd/loadbalancer/loadbalancer_acl.go
@@ -26,6 +26,7 @@ func loadbalancerACLRootCmd(f factory.ClientFactory) *cobra.Command {
 
 	// Child root commands
 	cmd.AddCommand(loadbalancerACLConditionRootCmd(f))
+	cmd.AddCommand(loadbalancerACLActionRootCmd(f))
 
 	return cmd
 }

--- a/cmd/loadbalancer/loadbalancer_acl_action.go
+++ b/cmd/loadbalancer/loadbalancer_acl_action.go
@@ -1,0 +1,330 @@
+package loadbalancer
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/ans-group/cli/internal/pkg/factory"
+	"github.com/ans-group/cli/internal/pkg/output"
+	"github.com/ans-group/sdk-go/pkg/service/loadbalancer"
+	"github.com/spf13/cobra"
+)
+
+func loadbalancerACLActionRootCmd(f factory.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "action",
+		Short: "sub-commands relating to ACLs",
+	}
+
+	// Child commands
+	cmd.AddCommand(loadbalancerACLActionListCmd(f))
+	cmd.AddCommand(loadbalancerACLActionShowCmd(f))
+	cmd.AddCommand(loadbalancerACLActionCreateCmd(f))
+	cmd.AddCommand(loadbalancerACLActionUpdateCmd(f))
+	cmd.AddCommand(loadbalancerACLActionDeleteCmd(f))
+
+	return cmd
+}
+func loadbalancerACLActionListCmd(f factory.ClientFactory) *cobra.Command {
+	return &cobra.Command{
+		Use:     "list <acl: id>",
+		Short:   "Lists ACL actions",
+		Long:    "This command lists ACL actions",
+		Example: "ans loadbalancer acl action list 123",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("Missing ACL")
+			}
+
+			return nil
+		},
+		RunE: loadbalancerCobraRunEFunc(f, loadbalancerACLActionList),
+	}
+}
+
+func loadbalancerACLActionList(service loadbalancer.LoadBalancerService, cmd *cobra.Command, args []string) error {
+	aclID, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("Invalid ACL ID [%s]", args[0])
+	}
+
+	acl, err := service.GetACL(aclID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving ACL [%d]: %s", aclID, err)
+	}
+
+	return output.CommandOutput(cmd, OutputLoadBalancerACLActionsProvider(mapACLActions(acl.Actions)))
+}
+
+func loadbalancerACLActionShowCmd(f factory.ClientFactory) *cobra.Command {
+	return &cobra.Command{
+		Use:     "show <acl: id> <action: index>...",
+		Short:   "Shows an ACL action",
+		Long:    "This command shows one or more ACL actions",
+		Example: "ans loadbalancer acl action show 123 0",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("Missing ACL")
+			}
+			if len(args) < 2 {
+				return errors.New("Missing ACL action index")
+			}
+
+			return nil
+		},
+		RunE: loadbalancerCobraRunEFunc(f, loadbalancerACLActionShow),
+	}
+}
+
+func loadbalancerACLActionShow(service loadbalancer.LoadBalancerService, cmd *cobra.Command, args []string) error {
+	var actions []ACLAction
+	aclID, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("Invalid ACL ID [%s]", args[0])
+	}
+
+	acl, err := service.GetACL(aclID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving ACL [%d]: %s", aclID, err)
+	}
+
+	for _, arg := range args[1:] {
+		actionIndex, err := strconv.Atoi(arg)
+		if err != nil {
+			output.OutputWithErrorLevelf("Invalid ACL action index [%s]", arg)
+			continue
+		}
+
+		if len(acl.Actions) < actionIndex+1 {
+			output.OutputWithErrorLevelf("ACL action index [%s] out of bounds", arg)
+			continue
+		}
+
+		actions = append(actions, mapACLAction(acl.Actions[actionIndex], actionIndex))
+	}
+
+	return output.CommandOutput(cmd, OutputLoadBalancerACLActionsProvider(actions))
+}
+
+func loadbalancerACLActionCreateCmd(f factory.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "create",
+		Short:   "Creates an ACL action",
+		Long:    "This command creates an ACL action",
+		Example: "ans loadbalancer acl action create 123 --name \"header_matches\" --argument \"host=ans.co.uk\"",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("Missing ACL")
+			}
+
+			return nil
+		},
+		RunE: loadbalancerCobraRunEFunc(f, loadbalancerACLActionCreate),
+	}
+
+	cmd.Flags().String("name", "", "Name of ACL action")
+	cmd.MarkFlagRequired("name")
+	cmd.Flags().StringArray("argument", []string{}, "ACL action argument. Can be repeated")
+
+	return cmd
+}
+
+func loadbalancerACLActionCreate(service loadbalancer.LoadBalancerService, cmd *cobra.Command, args []string) error {
+	aclID, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("Invalid ACL ID [%s]", args[0])
+	}
+
+	acl, err := service.GetACL(aclID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving ACL: %s", err)
+	}
+
+	action := loadbalancer.ACLAction{}
+	action.Name, _ = cmd.Flags().GetString("name")
+
+	if cmd.Flags().Changed("argument") {
+		actionArguments, _ := cmd.Flags().GetStringArray("argument")
+		actionArgumentsParsed, err := parseACLArguments(actionArguments)
+		if err != nil {
+			return fmt.Errorf("Failed to parse arguments: %s", err)
+		}
+
+		action.Arguments = actionArgumentsParsed
+	}
+
+	updateRequest := loadbalancer.PatchACLRequest{
+		Actions: append(acl.Actions, action),
+	}
+
+	err = service.PatchACL(aclID, updateRequest)
+	if err != nil {
+		return fmt.Errorf("Error updating ACL: %s", err)
+	}
+
+	acl, err = service.GetACL(aclID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving updated ACL [%d]: %s", aclID, err)
+	}
+
+	return output.CommandOutput(cmd, OutputLoadBalancerACLActionsProvider(mapACLActions(acl.Actions)))
+}
+
+func loadbalancerACLActionUpdateCmd(f factory.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "update <acl: id> <action: index>",
+		Short:   "Updates an ACL action",
+		Long:    "This command updates an ACL action",
+		Example: "ans loadbalancer acl action update 123 0 --name \"header_matches\"",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("Missing ACL")
+			}
+			if len(args) < 2 {
+				return errors.New("Missing ACL action index")
+			}
+
+			return nil
+		},
+		RunE: loadbalancerCobraRunEFunc(f, loadbalancerACLActionUpdate),
+	}
+
+	cmd.Flags().String("name", "", "Name of ACL action")
+	cmd.Flags().StringArray("argument", []string{}, "ACL action argument. Can be repeated")
+
+	return cmd
+}
+
+func loadbalancerACLActionUpdate(service loadbalancer.LoadBalancerService, cmd *cobra.Command, args []string) error {
+	aclID, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("Invalid ACL ID [%s]", args[0])
+	}
+
+	acl, err := service.GetACL(aclID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving ACL: %s", err)
+	}
+
+	actionIndex, err := strconv.Atoi(args[1])
+	if err != nil {
+		return fmt.Errorf("Invalid ACL action index [%s]", args[1])
+	}
+
+	if len(acl.Actions) < actionIndex+1 {
+		return fmt.Errorf("ACL action index [%d] out of bounds", actionIndex)
+	}
+
+	changed := false
+	if cmd.Flags().Changed("name") {
+		acl.Actions[actionIndex].Name, _ = cmd.Flags().GetString("name")
+		changed = true
+	}
+
+	if cmd.Flags().Changed("argument") {
+		actionArguments, _ := cmd.Flags().GetStringArray("argument")
+		actionArgumentsParsed, err := parseACLArguments(actionArguments)
+		if err != nil {
+			return fmt.Errorf("Failed to parse arguments: %s", err)
+		}
+
+		acl.Actions[actionIndex].Arguments = actionArgumentsParsed
+		changed = true
+	}
+
+	if changed {
+		updateRequest := loadbalancer.PatchACLRequest{
+			Actions: acl.Actions,
+		}
+
+		err = service.PatchACL(aclID, updateRequest)
+		if err != nil {
+			return fmt.Errorf("Error updating ACL: %s", err)
+		}
+	}
+
+	acl, err = service.GetACL(aclID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving updated ACL [%d]: %s", aclID, err)
+	}
+
+	return output.CommandOutput(cmd, OutputLoadBalancerACLActionsProvider(mapACLActions(acl.Actions)))
+}
+
+func loadbalancerACLActionDeleteCmd(f factory.ClientFactory) *cobra.Command {
+	return &cobra.Command{
+		Use:     "delete <acl: id> <action: index>...",
+		Short:   "Removes a acl",
+		Long:    "This command removes one or more acls",
+		Example: "ans loadbalancer acl delete 123",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("Missing ACL")
+			}
+			if len(args) < 2 {
+				return errors.New("Missing ACL action index")
+			}
+
+			return nil
+		},
+		RunE: loadbalancerCobraRunEFunc(f, loadbalancerACLActionDelete),
+	}
+}
+
+func loadbalancerACLActionDelete(service loadbalancer.LoadBalancerService, cmd *cobra.Command, args []string) error {
+	aclID, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("Invalid ACL ID [%s]", args[0])
+	}
+
+	acl, err := service.GetACL(aclID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving ACL: %s", err)
+	}
+
+	actionIndex, err := strconv.Atoi(args[1])
+	if err != nil {
+		return fmt.Errorf("Invalid ACL action index [%s]", args[1])
+	}
+
+	if len(acl.Actions) < actionIndex+1 {
+		return fmt.Errorf("ACL action index [%d] out of bounds", actionIndex)
+	}
+
+	actions := make([]loadbalancer.ACLAction, 0)
+	actions = append(actions, acl.Actions[:actionIndex]...)
+	actions = append(actions, acl.Actions[actionIndex+1:]...)
+
+	updateRequest := loadbalancer.PatchACLRequest{
+		Actions: actions,
+	}
+
+	err = service.PatchACL(aclID, updateRequest)
+	if err != nil {
+		return fmt.Errorf("Error updating ACL: %s", err)
+	}
+
+	acl, err = service.GetACL(aclID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving updated ACL [%d]: %s", aclID, err)
+	}
+
+	return output.CommandOutput(cmd, OutputLoadBalancerACLActionsProvider(mapACLActions(acl.Actions)))
+}
+
+func mapACLAction(action loadbalancer.ACLAction, index int) ACLAction {
+	return ACLAction{
+		ACLAction: action,
+		Index:     index,
+	}
+}
+
+func mapACLActions(actions []loadbalancer.ACLAction) []ACLAction {
+	var aclActions []ACLAction
+	for actionIndex, action := range actions {
+		aclActions = append(aclActions, mapACLAction(action, actionIndex))
+	}
+
+	return aclActions
+}

--- a/cmd/loadbalancer/loadbalancer_acl_action.go
+++ b/cmd/loadbalancer/loadbalancer_acl_action.go
@@ -254,7 +254,7 @@ func loadbalancerACLActionUpdate(service loadbalancer.LoadBalancerService, cmd *
 
 func loadbalancerACLActionDeleteCmd(f factory.ClientFactory) *cobra.Command {
 	return &cobra.Command{
-		Use:     "delete <acl: id> <action: index>...",
+		Use:     "delete <acl: id> <action: index>",
 		Short:   "Removes a acl",
 		Long:    "This command removes one or more acls",
 		Example: "ans loadbalancer acl delete 123",

--- a/cmd/loadbalancer/loadbalancer_acl_action_test.go
+++ b/cmd/loadbalancer/loadbalancer_acl_action_test.go
@@ -1,0 +1,572 @@
+package loadbalancer
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ans-group/cli/test/mocks"
+	"github.com/ans-group/sdk-go/pkg/service/loadbalancer"
+	gomock "github.com/golang/mock/gomock"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_loadbalancerACLActionListCmd_Args(t *testing.T) {
+	t.Run("ValidArgs_NoError", func(t *testing.T) {
+		err := loadbalancerACLActionListCmd(nil).Args(nil, []string{"123"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("InvalidArgs_Error", func(t *testing.T) {
+		err := loadbalancerACLActionListCmd(nil).Args(nil, []string{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing ACL", err.Error())
+	})
+}
+
+func Test_loadbalancerACLActionList(t *testing.T) {
+	t.Run("DefaultRetrieve", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+
+		service.EXPECT().GetACL(gomock.Any()).Return(loadbalancer.ACL{}, nil)
+
+		err := loadbalancerACLActionList(service, &cobra.Command{}, []string{"123"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("InvalidACLID_Error", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+
+		err := loadbalancerACLActionList(service, &cobra.Command{}, []string{"abc"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Invalid ACL ID [abc]", err.Error())
+	})
+
+	t.Run("GetACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+
+		service.EXPECT().GetACL(gomock.Any()).Return(loadbalancer.ACL{}, errors.New("test error"))
+
+		err := loadbalancerACLActionList(service, &cobra.Command{}, []string{"123"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Error retrieving ACL [123]: test error", err.Error())
+	})
+}
+
+func Test_loadbalancerACLActionShowCmd_Args(t *testing.T) {
+	t.Run("ValidArgs_NoError", func(t *testing.T) {
+		err := loadbalancerACLActionShowCmd(nil).Args(nil, []string{"123", "0"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("MissingACL_Error", func(t *testing.T) {
+		err := loadbalancerACLActionShowCmd(nil).Args(nil, []string{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing ACL", err.Error())
+	})
+
+	t.Run("MissingIndex_Error", func(t *testing.T) {
+		err := loadbalancerACLActionShowCmd(nil).Args(nil, []string{"123"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing ACL action index", err.Error())
+	})
+}
+
+func Test_loadbalancerACLActionShow(t *testing.T) {
+	t.Run("SingleACL", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+
+		service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil).Times(1)
+
+		err := loadbalancerACLActionShow(service, &cobra.Command{}, []string{"123"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("InvalidACLID_OutputsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+
+		err := loadbalancerACLActionShow(service, &cobra.Command{}, []string{"abc", "0"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Invalid ACL ID [abc]", err.Error())
+	})
+
+	t.Run("GetACLError_OutputsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+
+		service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, errors.New("test error"))
+
+		err := loadbalancerACLActionShow(service, &cobra.Command{}, []string{"123", "0"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Error retrieving ACL [123]: test error", err.Error())
+	})
+}
+
+func Test_loadbalancerACLActionCreateCmd_Args(t *testing.T) {
+	t.Run("ValidArgs_NoError", func(t *testing.T) {
+		err := loadbalancerACLActionCreateCmd(nil).Args(nil, []string{"123"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("MissingACL_Error", func(t *testing.T) {
+		err := loadbalancerACLActionCreateCmd(nil).Args(nil, []string{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing ACL", err.Error())
+	})
+}
+
+func Test_loadbalancerACLActionCreate(t *testing.T) {
+	t.Run("DefaultCreate_ExpectedPatch", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionCreateCmd(nil)
+		cmd.Flags().Set("name", "header_matches")
+		cmd.Flags().Set("argument", "header=host")
+		cmd.Flags().Set("argument", "value=test.com")
+
+		req := loadbalancer.PatchACLRequest{
+			Actions: []loadbalancer.ACLAction{
+				{
+					Name: "header_matches",
+					Arguments: map[string]loadbalancer.ACLArgument{
+						"header": {
+							Name:  "header",
+							Value: "host",
+						},
+						"value": {
+							Name:  "value",
+							Value: "test.com",
+						},
+					},
+				},
+			},
+		}
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil),
+			service.EXPECT().PatchACL(123, req).Return(nil),
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil),
+		)
+
+		err := loadbalancerACLActionCreate(service, cmd, []string{"123"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("GetACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionCreateCmd(nil)
+
+		service.EXPECT().GetACL(gomock.Any()).Return(loadbalancer.ACL{}, errors.New("test error"))
+
+		err := loadbalancerACLActionCreate(service, cmd, []string{"123"})
+
+		assert.Equal(t, "Error retrieving ACL: test error", err.Error())
+	})
+
+	t.Run("PatchACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionCreateCmd(nil)
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil),
+			service.EXPECT().PatchACL(123, gomock.Any()).Return(errors.New("test error")),
+		)
+
+		err := loadbalancerACLActionCreate(service, cmd, []string{"123"})
+
+		assert.Equal(t, "Error updating ACL: test error", err.Error())
+	})
+
+	t.Run("UpdatedGetACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionCreateCmd(nil)
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil),
+			service.EXPECT().PatchACL(123, gomock.Any()).Return(nil),
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, errors.New("test error")),
+		)
+
+		err := loadbalancerACLActionCreate(service, cmd, []string{"123"})
+
+		assert.Equal(t, "Error retrieving updated ACL [123]: test error", err.Error())
+	})
+}
+
+func Test_loadbalancerACLActionUpdateCmd_Args(t *testing.T) {
+	t.Run("ValidArgs_NoError", func(t *testing.T) {
+		err := loadbalancerACLActionUpdateCmd(nil).Args(nil, []string{"123", "0"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("MissingACL_Error", func(t *testing.T) {
+		err := loadbalancerACLActionUpdateCmd(nil).Args(nil, []string{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing ACL", err.Error())
+	})
+
+	t.Run("MissingACLActionIndex_Error", func(t *testing.T) {
+		err := loadbalancerACLActionUpdateCmd(nil).Args(nil, []string{"123"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing ACL action index", err.Error())
+	})
+}
+
+func Test_loadbalancerACLActionUpdate(t *testing.T) {
+	t.Run("DefaultUpdate_ExpectedPatch", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionUpdateCmd(nil)
+		cmd.Flags().Set("name", "header_matches")
+
+		req := loadbalancer.PatchACLRequest{
+			Actions: []loadbalancer.ACLAction{
+				{
+					Name: "header_matches",
+				},
+			},
+		}
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{
+				Actions: []loadbalancer.ACLAction{
+					{
+						Name: "redirect",
+					},
+				},
+			}, nil),
+			service.EXPECT().PatchACL(123, req).Return(nil),
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil),
+		)
+
+		err := loadbalancerACLActionUpdate(service, cmd, []string{"123", "0"})
+		assert.Nil(t, err)
+	})
+
+	t.Run("InvalidACLID_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionUpdateCmd(nil)
+
+		err := loadbalancerACLActionUpdate(service, cmd, []string{"abc"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Invalid ACL ID [abc]", err.Error())
+	})
+
+	t.Run("GetACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionUpdateCmd(nil)
+
+		service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, errors.New("test error"))
+
+		err := loadbalancerACLActionUpdate(service, cmd, []string{"123"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Error retrieving ACL: test error", err.Error())
+	})
+
+	t.Run("InvalidActionIndex_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionUpdateCmd(nil)
+
+		service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil)
+
+		err := loadbalancerACLActionUpdate(service, cmd, []string{"123", "abc"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Invalid ACL action index [abc]", err.Error())
+	})
+
+	t.Run("ActionIndexOutOfBounds_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionUpdateCmd(nil)
+
+		service.EXPECT().GetACL(123).Return(loadbalancer.ACL{
+			Actions: []loadbalancer.ACLAction{
+				{
+					Name: "redirect",
+				},
+			},
+		}, nil)
+
+		err := loadbalancerACLActionUpdate(service, cmd, []string{"123", "1"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "ACL action index [1] out of bounds", err.Error())
+	})
+
+	t.Run("PatchACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionUpdateCmd(nil)
+		cmd.Flags().Set("name", "header_matches")
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{
+				Actions: []loadbalancer.ACLAction{
+					{
+						Name: "redirect",
+					},
+				},
+			}, nil),
+			service.EXPECT().PatchACL(123, gomock.Any()).Return(errors.New("test error")),
+		)
+
+		err := loadbalancerACLActionUpdate(service, cmd, []string{"123", "0"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Error updating ACL: test error", err.Error())
+	})
+
+	t.Run("UpdatedGetACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionUpdateCmd(nil)
+		cmd.Flags().Set("name", "header_matches")
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{
+				Actions: []loadbalancer.ACLAction{
+					{
+						Name: "redirect",
+					},
+				},
+			}, nil),
+			service.EXPECT().PatchACL(123, gomock.Any()).Return(nil),
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, errors.New("test error")),
+		)
+
+		err := loadbalancerACLActionUpdate(service, cmd, []string{"123", "0"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Error retrieving updated ACL [123]: test error", err.Error())
+	})
+}
+
+func Test_loadbalancerACLActionDeleteCmd_Args(t *testing.T) {
+	t.Run("ValidArgs_NoError", func(t *testing.T) {
+		err := loadbalancerACLActionDeleteCmd(nil).Args(nil, []string{"123", "0"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("InvalidArgs_Error", func(t *testing.T) {
+		err := loadbalancerACLActionDeleteCmd(nil).Args(nil, []string{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing ACL", err.Error())
+	})
+
+	t.Run("MissingACLActionIndex_Error", func(t *testing.T) {
+		err := loadbalancerACLActionDeleteCmd(nil).Args(nil, []string{"123"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing ACL action index", err.Error())
+	})
+}
+
+func Test_loadbalancerACLActionDelete(t *testing.T) {
+	t.Run("DefaultDelete_ExpectedPatch", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionDeleteCmd(nil)
+		cmd.Flags().Set("name", "header_matches")
+
+		req := loadbalancer.PatchACLRequest{
+			Actions: make([]loadbalancer.ACLAction, 0),
+		}
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{
+				Actions: []loadbalancer.ACLAction{
+					{
+						Name: "redirect",
+					},
+				},
+			}, nil),
+			service.EXPECT().PatchACL(123, req).Return(nil),
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil),
+		)
+
+		err := loadbalancerACLActionDelete(service, cmd, []string{"123", "0"})
+		assert.Nil(t, err)
+	})
+
+	t.Run("InvalidACLID_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionDeleteCmd(nil)
+
+		err := loadbalancerACLActionDelete(service, cmd, []string{"abc"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Invalid ACL ID [abc]", err.Error())
+	})
+
+	t.Run("GetACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionDeleteCmd(nil)
+
+		service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, errors.New("test error"))
+
+		err := loadbalancerACLActionDelete(service, cmd, []string{"123"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Error retrieving ACL: test error", err.Error())
+	})
+
+	t.Run("InvalidActionIndex_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionDeleteCmd(nil)
+
+		service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil)
+
+		err := loadbalancerACLActionDelete(service, cmd, []string{"123", "abc"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Invalid ACL action index [abc]", err.Error())
+	})
+
+	t.Run("ActionIndexOutOfBounds_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionDeleteCmd(nil)
+
+		service.EXPECT().GetACL(123).Return(loadbalancer.ACL{
+			Actions: []loadbalancer.ACLAction{
+				{
+					Name: "redirect",
+				},
+			},
+		}, nil)
+
+		err := loadbalancerACLActionDelete(service, cmd, []string{"123", "1"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "ACL action index [1] out of bounds", err.Error())
+	})
+
+	t.Run("PatchACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionDeleteCmd(nil)
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{
+				Actions: []loadbalancer.ACLAction{
+					{
+						Name: "redirect",
+					},
+				},
+			}, nil),
+			service.EXPECT().PatchACL(123, gomock.Any()).Return(errors.New("test error")),
+		)
+
+		err := loadbalancerACLActionDelete(service, cmd, []string{"123", "0"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Error updating ACL: test error", err.Error())
+	})
+
+	t.Run("UpdatedGetACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLActionDeleteCmd(nil)
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{
+				Actions: []loadbalancer.ACLAction{
+					{
+						Name: "redirect",
+					},
+				},
+			}, nil),
+			service.EXPECT().PatchACL(123, gomock.Any()).Return(nil),
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, errors.New("test error")),
+		)
+
+		err := loadbalancerACLActionDelete(service, cmd, []string{"123", "0"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Error retrieving updated ACL [123]: test error", err.Error())
+	})
+}

--- a/cmd/loadbalancer/loadbalancer_acl_condition.go
+++ b/cmd/loadbalancer/loadbalancer_acl_condition.go
@@ -1,0 +1,338 @@
+package loadbalancer
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/ans-group/cli/internal/pkg/factory"
+	"github.com/ans-group/cli/internal/pkg/output"
+	"github.com/ans-group/sdk-go/pkg/service/loadbalancer"
+	"github.com/spf13/cobra"
+)
+
+func loadbalancerACLConditionRootCmd(f factory.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "condition",
+		Short: "sub-commands relating to ACLs",
+	}
+
+	// Child commands
+	cmd.AddCommand(loadbalancerACLConditionListCmd(f))
+	cmd.AddCommand(loadbalancerACLConditionShowCmd(f))
+	cmd.AddCommand(loadbalancerACLConditionCreateCmd(f))
+	cmd.AddCommand(loadbalancerACLConditionUpdateCmd(f))
+	cmd.AddCommand(loadbalancerACLConditionDeleteCmd(f))
+
+	return cmd
+}
+func loadbalancerACLConditionListCmd(f factory.ClientFactory) *cobra.Command {
+	return &cobra.Command{
+		Use:     "list <acl: id>",
+		Short:   "Lists ACL conditions",
+		Long:    "This command lists ACL conditions",
+		Example: "ans loadbalancer acl condition list 123",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("Missing ACL")
+			}
+
+			return nil
+		},
+		RunE: loadbalancerCobraRunEFunc(f, loadbalancerACLConditionList),
+	}
+}
+
+func loadbalancerACLConditionList(service loadbalancer.LoadBalancerService, cmd *cobra.Command, args []string) error {
+	aclID, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("Invalid ACL ID [%s]", args[0])
+	}
+
+	acl, err := service.GetACL(aclID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving ACL [%d]: %s", aclID, err)
+	}
+
+	return output.CommandOutput(cmd, OutputLoadBalancerACLConditionsProvider(mapACLConditions(acl.Conditions)))
+}
+
+func loadbalancerACLConditionShowCmd(f factory.ClientFactory) *cobra.Command {
+	return &cobra.Command{
+		Use:     "show <acl: id> <condition: index>...",
+		Short:   "Shows an ACL condition",
+		Long:    "This command shows one or more ACL conditions",
+		Example: "ans loadbalancer acl condition show 123 0",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("Missing ACL")
+			}
+			if len(args) < 2 {
+				return errors.New("Missing ACL condition index")
+			}
+
+			return nil
+		},
+		RunE: loadbalancerCobraRunEFunc(f, loadbalancerACLConditionShow),
+	}
+}
+
+func loadbalancerACLConditionShow(service loadbalancer.LoadBalancerService, cmd *cobra.Command, args []string) error {
+	var conditions []ACLCondition
+	aclID, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("Invalid ACL ID [%s]", args[0])
+	}
+
+	acl, err := service.GetACL(aclID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving ACL [%d]: %s", aclID, err)
+	}
+
+	for _, arg := range args[1:] {
+		conditionIndex, err := strconv.Atoi(args[1])
+		if err != nil {
+			output.OutputWithErrorLevelf("Invalid ACL condition index [%s]", arg)
+			continue
+		}
+
+		if len(acl.Conditions) < conditionIndex+1 {
+			output.OutputWithErrorLevelf("ACL condition index [%s] out of bounds", arg)
+			continue
+		}
+
+		conditions = append(conditions, mapACLCondition(acl.Conditions[conditionIndex], conditionIndex))
+	}
+
+	return output.CommandOutput(cmd, OutputLoadBalancerACLConditionsProvider(conditions))
+}
+
+func loadbalancerACLConditionCreateCmd(f factory.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "create",
+		Short:   "Creates an ACL condition",
+		Long:    "This command creates an ACL condition",
+		Example: "ans loadbalancer acl condition create 123 --name \"header_matches\" --argument \"host=ans.co.uk\"",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("Missing ACL")
+			}
+
+			return nil
+		},
+		RunE: loadbalancerCobraRunEFunc(f, loadbalancerACLConditionCreate),
+	}
+
+	cmd.Flags().String("name", "", "Name of ACL condition")
+	cmd.MarkFlagRequired("name")
+	cmd.Flags().StringArray("argument", []string{}, "ACL condition argument. Can be repeated")
+	cmd.Flags().Bool("inverted", false, "Specifies ACL condition should be inverted")
+
+	return cmd
+}
+
+func loadbalancerACLConditionCreate(service loadbalancer.LoadBalancerService, cmd *cobra.Command, args []string) error {
+	aclID, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("Invalid ACL ID [%s]", args[0])
+	}
+
+	acl, err := service.GetACL(aclID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving ACL: %s", err)
+	}
+
+	condition := loadbalancer.ACLCondition{}
+	condition.Name, _ = cmd.Flags().GetString("name")
+	condition.Inverted, _ = cmd.Flags().GetBool("inverted")
+
+	if cmd.Flags().Changed("argument") {
+		conditionArguments, _ := cmd.Flags().GetStringArray("argument")
+		conditionArgumentsParsed, err := parseACLArguments(conditionArguments)
+		if err != nil {
+			return fmt.Errorf("Failed to parse arguments: %s", err)
+		}
+
+		condition.Arguments = conditionArgumentsParsed
+	}
+
+	updateRequest := loadbalancer.PatchACLRequest{
+		Conditions: append(acl.Conditions, condition),
+	}
+
+	err = service.PatchACL(aclID, updateRequest)
+	if err != nil {
+		return fmt.Errorf("Error updating ACL: %s", err)
+	}
+
+	acl, err = service.GetACL(aclID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving updated ACL [%d]: %s", aclID, err)
+	}
+
+	return output.CommandOutput(cmd, OutputLoadBalancerACLConditionsProvider(mapACLConditions(acl.Conditions)))
+}
+
+func loadbalancerACLConditionUpdateCmd(f factory.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "update <acl: id> <condition: index>",
+		Short:   "Updates an ACL condition",
+		Long:    "This command updates an ACL condition",
+		Example: "ans loadbalancer acl condition update 123 0 --name \"header_matches\"",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("Missing ACL")
+			}
+			if len(args) < 1 {
+				return errors.New("Missing ACL condition index")
+			}
+
+			return nil
+		},
+		RunE: loadbalancerCobraRunEFunc(f, loadbalancerACLConditionUpdate),
+	}
+
+	cmd.Flags().String("name", "", "Name of ACL condition")
+	cmd.Flags().StringArray("argument", []string{}, "ACL condition argument. Can be repeated")
+	cmd.Flags().Bool("inverted", false, "Specifies ACL condition should be inverted")
+
+	return cmd
+}
+
+func loadbalancerACLConditionUpdate(service loadbalancer.LoadBalancerService, cmd *cobra.Command, args []string) error {
+	aclID, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("Invalid ACL ID [%s]", args[0])
+	}
+
+	acl, err := service.GetACL(aclID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving ACL: %s", err)
+	}
+
+	conditionIndex, err := strconv.Atoi(args[1])
+	if err != nil {
+		return fmt.Errorf("Invalid ACL condition index [%s]", args[1])
+	}
+
+	if len(acl.Conditions) < conditionIndex+1 {
+		return fmt.Errorf("ACL condition index [%d] out of bounds", conditionIndex)
+	}
+
+	changed := false
+	if cmd.Flags().Changed("name") {
+		acl.Conditions[conditionIndex].Name, _ = cmd.Flags().GetString("name")
+		changed = true
+	}
+
+	if cmd.Flags().Changed("inverted") {
+		acl.Conditions[conditionIndex].Inverted, _ = cmd.Flags().GetBool("inverted")
+		changed = true
+	}
+
+	if cmd.Flags().Changed("argument") {
+		conditionArguments, _ := cmd.Flags().GetStringArray("argument")
+		conditionArgumentsParsed, err := parseACLArguments(conditionArguments)
+		if err != nil {
+			return fmt.Errorf("Failed to parse arguments: %s", err)
+		}
+
+		acl.Conditions[conditionIndex].Arguments = conditionArgumentsParsed
+		changed = true
+	}
+
+	if changed {
+		updateRequest := loadbalancer.PatchACLRequest{
+			Conditions: acl.Conditions,
+		}
+
+		err = service.PatchACL(aclID, updateRequest)
+		if err != nil {
+			return fmt.Errorf("Error updating ACL: %s", err)
+		}
+	}
+
+	acl, err = service.GetACL(aclID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving updated ACL [%d]: %s", aclID, err)
+	}
+
+	return output.CommandOutput(cmd, OutputLoadBalancerACLConditionsProvider(mapACLConditions(acl.Conditions)))
+}
+
+func loadbalancerACLConditionDeleteCmd(f factory.ClientFactory) *cobra.Command {
+	return &cobra.Command{
+		Use:     "delete <acl: id>...",
+		Short:   "Removes a acl",
+		Long:    "This command removes one or more acls",
+		Example: "ans loadbalancer acl delete 123",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("Missing ACL")
+			}
+			if len(args) < 1 {
+				return errors.New("Missing ACL condition index")
+			}
+
+			return nil
+		},
+		RunE: loadbalancerCobraRunEFunc(f, loadbalancerACLConditionDelete),
+	}
+}
+
+func loadbalancerACLConditionDelete(service loadbalancer.LoadBalancerService, cmd *cobra.Command, args []string) error {
+	aclID, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("Invalid ACL ID [%s]", args[0])
+	}
+
+	acl, err := service.GetACL(aclID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving ACL: %s", err)
+	}
+
+	conditionIndex, err := strconv.Atoi(args[1])
+	if err != nil {
+		return fmt.Errorf("Invalid ACL condition index [%s]", args[1])
+	}
+
+	if len(acl.Conditions) < conditionIndex+1 {
+		return fmt.Errorf("ACL condition index [%d] out of bounds", conditionIndex)
+	}
+
+	conditions := make([]loadbalancer.ACLCondition, 0)
+	conditions = append(conditions, acl.Conditions[:conditionIndex]...)
+	conditions = append(conditions, acl.Conditions[conditionIndex+1:]...)
+
+	updateRequest := loadbalancer.PatchACLRequest{
+		Conditions: conditions,
+	}
+
+	err = service.PatchACL(aclID, updateRequest)
+	if err != nil {
+		return fmt.Errorf("Error updating ACL: %s", err)
+	}
+
+	acl, err = service.GetACL(aclID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving updated ACL [%d]: %s", aclID, err)
+	}
+
+	return output.CommandOutput(cmd, OutputLoadBalancerACLConditionsProvider(mapACLConditions(acl.Conditions)))
+}
+
+func mapACLCondition(condition loadbalancer.ACLCondition, index int) ACLCondition {
+	return ACLCondition{
+		ACLCondition: condition,
+		Index:        index,
+	}
+}
+
+func mapACLConditions(conditions []loadbalancer.ACLCondition) []ACLCondition {
+	var aclConditions []ACLCondition
+	for conditionIndex, condition := range conditions {
+		aclConditions = append(aclConditions, mapACLCondition(condition, conditionIndex))
+	}
+
+	return aclConditions
+}

--- a/cmd/loadbalancer/loadbalancer_acl_condition.go
+++ b/cmd/loadbalancer/loadbalancer_acl_condition.go
@@ -262,7 +262,7 @@ func loadbalancerACLConditionUpdate(service loadbalancer.LoadBalancerService, cm
 
 func loadbalancerACLConditionDeleteCmd(f factory.ClientFactory) *cobra.Command {
 	return &cobra.Command{
-		Use:     "delete <acl: id> <condition: index>...",
+		Use:     "delete <acl: id> <condition: index>",
 		Short:   "Removes a acl",
 		Long:    "This command removes one or more acls",
 		Example: "ans loadbalancer acl delete 123",

--- a/cmd/loadbalancer/loadbalancer_acl_condition.go
+++ b/cmd/loadbalancer/loadbalancer_acl_condition.go
@@ -90,7 +90,7 @@ func loadbalancerACLConditionShow(service loadbalancer.LoadBalancerService, cmd 
 	}
 
 	for _, arg := range args[1:] {
-		conditionIndex, err := strconv.Atoi(args[1])
+		conditionIndex, err := strconv.Atoi(arg)
 		if err != nil {
 			output.OutputWithErrorLevelf("Invalid ACL condition index [%s]", arg)
 			continue
@@ -183,7 +183,7 @@ func loadbalancerACLConditionUpdateCmd(f factory.ClientFactory) *cobra.Command {
 			if len(args) < 1 {
 				return errors.New("Missing ACL")
 			}
-			if len(args) < 1 {
+			if len(args) < 2 {
 				return errors.New("Missing ACL condition index")
 			}
 
@@ -262,7 +262,7 @@ func loadbalancerACLConditionUpdate(service loadbalancer.LoadBalancerService, cm
 
 func loadbalancerACLConditionDeleteCmd(f factory.ClientFactory) *cobra.Command {
 	return &cobra.Command{
-		Use:     "delete <acl: id>...",
+		Use:     "delete <acl: id> <condition: index>...",
 		Short:   "Removes a acl",
 		Long:    "This command removes one or more acls",
 		Example: "ans loadbalancer acl delete 123",
@@ -270,7 +270,7 @@ func loadbalancerACLConditionDeleteCmd(f factory.ClientFactory) *cobra.Command {
 			if len(args) < 1 {
 				return errors.New("Missing ACL")
 			}
-			if len(args) < 1 {
+			if len(args) < 2 {
 				return errors.New("Missing ACL condition index")
 			}
 

--- a/cmd/loadbalancer/loadbalancer_acl_condition_test.go
+++ b/cmd/loadbalancer/loadbalancer_acl_condition_test.go
@@ -1,0 +1,572 @@
+package loadbalancer
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ans-group/cli/test/mocks"
+	"github.com/ans-group/sdk-go/pkg/service/loadbalancer"
+	gomock "github.com/golang/mock/gomock"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_loadbalancerACLConditionListCmd_Args(t *testing.T) {
+	t.Run("ValidArgs_NoError", func(t *testing.T) {
+		err := loadbalancerACLConditionListCmd(nil).Args(nil, []string{"123"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("InvalidArgs_Error", func(t *testing.T) {
+		err := loadbalancerACLConditionListCmd(nil).Args(nil, []string{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing ACL", err.Error())
+	})
+}
+
+func Test_loadbalancerACLConditionList(t *testing.T) {
+	t.Run("DefaultRetrieve", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+
+		service.EXPECT().GetACL(gomock.Any()).Return(loadbalancer.ACL{}, nil)
+
+		err := loadbalancerACLConditionList(service, &cobra.Command{}, []string{"123"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("InvalidACLID_Error", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+
+		err := loadbalancerACLConditionList(service, &cobra.Command{}, []string{"abc"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Invalid ACL ID [abc]", err.Error())
+	})
+
+	t.Run("GetACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+
+		service.EXPECT().GetACL(gomock.Any()).Return(loadbalancer.ACL{}, errors.New("test error"))
+
+		err := loadbalancerACLConditionList(service, &cobra.Command{}, []string{"123"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Error retrieving ACL [123]: test error", err.Error())
+	})
+}
+
+func Test_loadbalancerACLConditionShowCmd_Args(t *testing.T) {
+	t.Run("ValidArgs_NoError", func(t *testing.T) {
+		err := loadbalancerACLConditionShowCmd(nil).Args(nil, []string{"123", "0"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("MissingACL_Error", func(t *testing.T) {
+		err := loadbalancerACLConditionShowCmd(nil).Args(nil, []string{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing ACL", err.Error())
+	})
+
+	t.Run("MissingIndex_Error", func(t *testing.T) {
+		err := loadbalancerACLConditionShowCmd(nil).Args(nil, []string{"123"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing ACL condition index", err.Error())
+	})
+}
+
+func Test_loadbalancerACLConditionShow(t *testing.T) {
+	t.Run("SingleACL", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+
+		service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil).Times(1)
+
+		err := loadbalancerACLConditionShow(service, &cobra.Command{}, []string{"123"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("InvalidACLID_OutputsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+
+		err := loadbalancerACLConditionShow(service, &cobra.Command{}, []string{"abc", "0"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Invalid ACL ID [abc]", err.Error())
+	})
+
+	t.Run("GetACLError_OutputsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+
+		service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, errors.New("test error"))
+
+		err := loadbalancerACLConditionShow(service, &cobra.Command{}, []string{"123", "0"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Error retrieving ACL [123]: test error", err.Error())
+	})
+}
+
+func Test_loadbalancerACLConditionCreateCmd_Args(t *testing.T) {
+	t.Run("ValidArgs_NoError", func(t *testing.T) {
+		err := loadbalancerACLConditionCreateCmd(nil).Args(nil, []string{"123"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("MissingACL_Error", func(t *testing.T) {
+		err := loadbalancerACLConditionCreateCmd(nil).Args(nil, []string{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing ACL", err.Error())
+	})
+}
+
+func Test_loadbalancerACLConditionCreate(t *testing.T) {
+	t.Run("DefaultCreate_ExpectedPatch", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionCreateCmd(nil)
+		cmd.Flags().Set("name", "header_matches")
+		cmd.Flags().Set("argument", "header=host")
+		cmd.Flags().Set("argument", "value=test.com")
+
+		req := loadbalancer.PatchACLRequest{
+			Conditions: []loadbalancer.ACLCondition{
+				{
+					Name: "header_matches",
+					Arguments: map[string]loadbalancer.ACLArgument{
+						"header": {
+							Name:  "header",
+							Value: "host",
+						},
+						"value": {
+							Name:  "value",
+							Value: "test.com",
+						},
+					},
+				},
+			},
+		}
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil),
+			service.EXPECT().PatchACL(123, req).Return(nil),
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil),
+		)
+
+		err := loadbalancerACLConditionCreate(service, cmd, []string{"123"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("GetACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionCreateCmd(nil)
+
+		service.EXPECT().GetACL(gomock.Any()).Return(loadbalancer.ACL{}, errors.New("test error"))
+
+		err := loadbalancerACLConditionCreate(service, cmd, []string{"123"})
+
+		assert.Equal(t, "Error retrieving ACL: test error", err.Error())
+	})
+
+	t.Run("PatchACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionCreateCmd(nil)
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil),
+			service.EXPECT().PatchACL(123, gomock.Any()).Return(errors.New("test error")),
+		)
+
+		err := loadbalancerACLConditionCreate(service, cmd, []string{"123"})
+
+		assert.Equal(t, "Error updating ACL: test error", err.Error())
+	})
+
+	t.Run("UpdatedGetACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionCreateCmd(nil)
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil),
+			service.EXPECT().PatchACL(123, gomock.Any()).Return(nil),
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, errors.New("test error")),
+		)
+
+		err := loadbalancerACLConditionCreate(service, cmd, []string{"123"})
+
+		assert.Equal(t, "Error retrieving updated ACL [123]: test error", err.Error())
+	})
+}
+
+func Test_loadbalancerACLConditionUpdateCmd_Args(t *testing.T) {
+	t.Run("ValidArgs_NoError", func(t *testing.T) {
+		err := loadbalancerACLConditionUpdateCmd(nil).Args(nil, []string{"123", "0"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("MissingACL_Error", func(t *testing.T) {
+		err := loadbalancerACLConditionUpdateCmd(nil).Args(nil, []string{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing ACL", err.Error())
+	})
+
+	t.Run("MissingACLConditionIndex_Error", func(t *testing.T) {
+		err := loadbalancerACLConditionUpdateCmd(nil).Args(nil, []string{"123"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing ACL condition index", err.Error())
+	})
+}
+
+func Test_loadbalancerACLConditionUpdate(t *testing.T) {
+	t.Run("DefaultUpdate_ExpectedPatch", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionUpdateCmd(nil)
+		cmd.Flags().Set("name", "header_matches")
+
+		req := loadbalancer.PatchACLRequest{
+			Conditions: []loadbalancer.ACLCondition{
+				{
+					Name: "header_matches",
+				},
+			},
+		}
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{
+				Conditions: []loadbalancer.ACLCondition{
+					{
+						Name: "redirect",
+					},
+				},
+			}, nil),
+			service.EXPECT().PatchACL(123, req).Return(nil),
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil),
+		)
+
+		err := loadbalancerACLConditionUpdate(service, cmd, []string{"123", "0"})
+		assert.Nil(t, err)
+	})
+
+	t.Run("InvalidACLID_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionUpdateCmd(nil)
+
+		err := loadbalancerACLConditionUpdate(service, cmd, []string{"abc"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Invalid ACL ID [abc]", err.Error())
+	})
+
+	t.Run("GetACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionUpdateCmd(nil)
+
+		service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, errors.New("test error"))
+
+		err := loadbalancerACLConditionUpdate(service, cmd, []string{"123"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Error retrieving ACL: test error", err.Error())
+	})
+
+	t.Run("InvalidConditionIndex_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionUpdateCmd(nil)
+
+		service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil)
+
+		err := loadbalancerACLConditionUpdate(service, cmd, []string{"123", "abc"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Invalid ACL condition index [abc]", err.Error())
+	})
+
+	t.Run("ConditionIndexOutOfBounds_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionUpdateCmd(nil)
+
+		service.EXPECT().GetACL(123).Return(loadbalancer.ACL{
+			Conditions: []loadbalancer.ACLCondition{
+				{
+					Name: "redirect",
+				},
+			},
+		}, nil)
+
+		err := loadbalancerACLConditionUpdate(service, cmd, []string{"123", "1"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "ACL condition index [1] out of bounds", err.Error())
+	})
+
+	t.Run("PatchACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionUpdateCmd(nil)
+		cmd.Flags().Set("name", "header_matches")
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{
+				Conditions: []loadbalancer.ACLCondition{
+					{
+						Name: "redirect",
+					},
+				},
+			}, nil),
+			service.EXPECT().PatchACL(123, gomock.Any()).Return(errors.New("test error")),
+		)
+
+		err := loadbalancerACLConditionUpdate(service, cmd, []string{"123", "0"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Error updating ACL: test error", err.Error())
+	})
+
+	t.Run("UpdatedGetACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionUpdateCmd(nil)
+		cmd.Flags().Set("name", "header_matches")
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{
+				Conditions: []loadbalancer.ACLCondition{
+					{
+						Name: "redirect",
+					},
+				},
+			}, nil),
+			service.EXPECT().PatchACL(123, gomock.Any()).Return(nil),
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, errors.New("test error")),
+		)
+
+		err := loadbalancerACLConditionUpdate(service, cmd, []string{"123", "0"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Error retrieving updated ACL [123]: test error", err.Error())
+	})
+}
+
+func Test_loadbalancerACLConditionDeleteCmd_Args(t *testing.T) {
+	t.Run("ValidArgs_NoError", func(t *testing.T) {
+		err := loadbalancerACLConditionDeleteCmd(nil).Args(nil, []string{"123", "0"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("InvalidArgs_Error", func(t *testing.T) {
+		err := loadbalancerACLConditionDeleteCmd(nil).Args(nil, []string{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing ACL", err.Error())
+	})
+
+	t.Run("MissingACLConditionIndex_Error", func(t *testing.T) {
+		err := loadbalancerACLConditionDeleteCmd(nil).Args(nil, []string{"123"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing ACL condition index", err.Error())
+	})
+}
+
+func Test_loadbalancerACLConditionDelete(t *testing.T) {
+	t.Run("DefaultDelete_ExpectedPatch", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionDeleteCmd(nil)
+		cmd.Flags().Set("name", "header_matches")
+
+		req := loadbalancer.PatchACLRequest{
+			Conditions: make([]loadbalancer.ACLCondition, 0),
+		}
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{
+				Conditions: []loadbalancer.ACLCondition{
+					{
+						Name: "redirect",
+					},
+				},
+			}, nil),
+			service.EXPECT().PatchACL(123, req).Return(nil),
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil),
+		)
+
+		err := loadbalancerACLConditionDelete(service, cmd, []string{"123", "0"})
+		assert.Nil(t, err)
+	})
+
+	t.Run("InvalidACLID_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionDeleteCmd(nil)
+
+		err := loadbalancerACLConditionDelete(service, cmd, []string{"abc"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Invalid ACL ID [abc]", err.Error())
+	})
+
+	t.Run("GetACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionDeleteCmd(nil)
+
+		service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, errors.New("test error"))
+
+		err := loadbalancerACLConditionDelete(service, cmd, []string{"123"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Error retrieving ACL: test error", err.Error())
+	})
+
+	t.Run("InvalidConditionIndex_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionDeleteCmd(nil)
+
+		service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, nil)
+
+		err := loadbalancerACLConditionDelete(service, cmd, []string{"123", "abc"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Invalid ACL condition index [abc]", err.Error())
+	})
+
+	t.Run("ConditionIndexOutOfBounds_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionDeleteCmd(nil)
+
+		service.EXPECT().GetACL(123).Return(loadbalancer.ACL{
+			Conditions: []loadbalancer.ACLCondition{
+				{
+					Name: "redirect",
+				},
+			},
+		}, nil)
+
+		err := loadbalancerACLConditionDelete(service, cmd, []string{"123", "1"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "ACL condition index [1] out of bounds", err.Error())
+	})
+
+	t.Run("PatchACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionDeleteCmd(nil)
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{
+				Conditions: []loadbalancer.ACLCondition{
+					{
+						Name: "redirect",
+					},
+				},
+			}, nil),
+			service.EXPECT().PatchACL(123, gomock.Any()).Return(errors.New("test error")),
+		)
+
+		err := loadbalancerACLConditionDelete(service, cmd, []string{"123", "0"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Error updating ACL: test error", err.Error())
+	})
+
+	t.Run("UpdatedGetACLError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockLoadBalancerService(mockCtrl)
+		cmd := loadbalancerACLConditionDeleteCmd(nil)
+
+		gomock.InOrder(
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{
+				Conditions: []loadbalancer.ACLCondition{
+					{
+						Name: "redirect",
+					},
+				},
+			}, nil),
+			service.EXPECT().PatchACL(123, gomock.Any()).Return(nil),
+			service.EXPECT().GetACL(123).Return(loadbalancer.ACL{}, errors.New("test error")),
+		)
+
+		err := loadbalancerACLConditionDelete(service, cmd, []string{"123", "0"})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Error retrieving updated ACL [123]: test error", err.Error())
+	})
+}

--- a/cmd/loadbalancer/loadbalancer_acl_test.go
+++ b/cmd/loadbalancer/loadbalancer_acl_test.go
@@ -271,82 +271,82 @@ func Test_loadbalancerACLDelete(t *testing.T) {
 	})
 }
 
-func Test_parseACLStatementFlag(t *testing.T) {
-	t.Run("SingleArgumentExpectedReturnValue", func(t *testing.T) {
-		name, parsedArgs, err := parseACLStatementFlag("name1:arg1=testvalue1")
+// func Test_parseACLStatementFlag(t *testing.T) {
+// 	t.Run("SingleArgumentExpectedReturnValue", func(t *testing.T) {
+// 		name, parsedArgs, err := parseACLStatementFlag("name1:arg1=testvalue1")
 
-		assert.Nil(t, err)
-		assert.Equal(t, "name1", name)
-		assert.Equal(t, "arg1", parsedArgs["arg1"].Name)
-		assert.Equal(t, "testvalue1", parsedArgs["arg1"].Value)
-	})
+// 		assert.Nil(t, err)
+// 		assert.Equal(t, "name1", name)
+// 		assert.Equal(t, "arg1", parsedArgs["arg1"].Name)
+// 		assert.Equal(t, "testvalue1", parsedArgs["arg1"].Value)
+// 	})
 
-	t.Run("MultipleArgumentsExpectedReturnValue", func(t *testing.T) {
-		name, parsedArgs, err := parseACLStatementFlag("name1:arg1=testvalue1,arg2=testvalue2")
+// 	t.Run("MultipleArgumentsExpectedReturnValue", func(t *testing.T) {
+// 		name, parsedArgs, err := parseACLStatementFlag("name1:arg1=testvalue1,arg2=testvalue2")
 
-		assert.Nil(t, err)
-		assert.Equal(t, "name1", name)
-		assert.Equal(t, "arg1", parsedArgs["arg1"].Name)
-		assert.Equal(t, "testvalue1", parsedArgs["arg1"].Value)
-		assert.Equal(t, "arg2", parsedArgs["arg2"].Name)
-		assert.Equal(t, "testvalue2", parsedArgs["arg2"].Value)
-	})
+// 		assert.Nil(t, err)
+// 		assert.Equal(t, "name1", name)
+// 		assert.Equal(t, "arg1", parsedArgs["arg1"].Name)
+// 		assert.Equal(t, "testvalue1", parsedArgs["arg1"].Value)
+// 		assert.Equal(t, "arg2", parsedArgs["arg2"].Name)
+// 		assert.Equal(t, "testvalue2", parsedArgs["arg2"].Value)
+// 	})
 
-	t.Run("InvalidNameReturnsError", func(t *testing.T) {
-		_, _, err := parseACLStatementFlag("arg1=testvalue1,arg2=testvalue2")
+// 	t.Run("InvalidNameReturnsError", func(t *testing.T) {
+// 		_, _, err := parseACLStatementFlag("arg1=testvalue1,arg2=testvalue2")
 
-		assert.NotNil(t, err)
-		assert.Equal(t, "invalid flag format. Expected format name:arguments", err.Error())
-	})
-}
+// 		assert.NotNil(t, err)
+// 		assert.Equal(t, "invalid flag format. Expected format name:arguments", err.Error())
+// 	})
+// }
 
-func Test_parseACLArguments(t *testing.T) {
-	t.Run("SingleArgumentExpectedReturnValue", func(t *testing.T) {
-		parsedArgs := []string{
-			"arg1=testvalue1",
-		}
-		parsed, err := parseACLArguments(parsedArgs)
+// func Test_parseACLArguments(t *testing.T) {
+// 	t.Run("SingleArgumentExpectedReturnValue", func(t *testing.T) {
+// 		parsedArgs := []string{
+// 			"arg1=testvalue1",
+// 		}
+// 		parsed, err := parseACLArguments(parsedArgs)
 
-		assert.Nil(t, err)
-		assert.Equal(t, "arg1", parsed["arg1"].Name)
-		assert.Equal(t, "testvalue1", parsed["arg1"].Value)
-	})
+// 		assert.Nil(t, err)
+// 		assert.Equal(t, "arg1", parsed["arg1"].Name)
+// 		assert.Equal(t, "testvalue1", parsed["arg1"].Value)
+// 	})
 
-	t.Run("MultipleArgumentsExpectedReturnValue", func(t *testing.T) {
-		parsedArgs := []string{
-			"arg1=testvalue1",
-			"arg2=testvalue2",
-		}
-		parsed, err := parseACLArguments(parsedArgs)
+// 	t.Run("MultipleArgumentsExpectedReturnValue", func(t *testing.T) {
+// 		parsedArgs := []string{
+// 			"arg1=testvalue1",
+// 			"arg2=testvalue2",
+// 		}
+// 		parsed, err := parseACLArguments(parsedArgs)
 
-		assert.Nil(t, err)
-		assert.Equal(t, "arg1", parsed["arg1"].Name)
-		assert.Equal(t, "testvalue1", parsed["arg1"].Value)
-		assert.Equal(t, "arg2", parsed["arg2"].Name)
-		assert.Equal(t, "testvalue2", parsed["arg2"].Value)
-	})
+// 		assert.Nil(t, err)
+// 		assert.Equal(t, "arg1", parsed["arg1"].Name)
+// 		assert.Equal(t, "testvalue1", parsed["arg1"].Value)
+// 		assert.Equal(t, "arg2", parsed["arg2"].Name)
+// 		assert.Equal(t, "testvalue2", parsed["arg2"].Value)
+// 	})
 
-	t.Run("ArrayValueArgumentExpectedReturnValue", func(t *testing.T) {
-		parsedArgs := []string{
-			"arg1[]=testvalue1",
-		}
-		parsed, err := parseACLArguments(parsedArgs)
+// 	t.Run("ArrayValueArgumentExpectedReturnValue", func(t *testing.T) {
+// 		parsedArgs := []string{
+// 			"arg1[]=testvalue1",
+// 		}
+// 		parsed, err := parseACLArguments(parsedArgs)
 
-		assert.Nil(t, err)
-		assert.Equal(t, "arg1", parsed["arg1"].Name)
-		assert.Equal(t, "testvalue1", parsed["arg1"].Value.([]string)[0])
-	})
+// 		assert.Nil(t, err)
+// 		assert.Equal(t, "arg1", parsed["arg1"].Name)
+// 		assert.Equal(t, "testvalue1", parsed["arg1"].Value.([]string)[0])
+// 	})
 
-	t.Run("MultipleArrayValueArgumentsExpectedReturnValue", func(t *testing.T) {
-		parsedArgs := []string{
-			"arg1[]=testvalue1",
-			"arg1[]=testvalue2",
-		}
-		parsed, err := parseACLArguments(parsedArgs)
+// 	t.Run("MultipleArrayValueArgumentsExpectedReturnValue", func(t *testing.T) {
+// 		parsedArgs := []string{
+// 			"arg1[]=testvalue1",
+// 			"arg1[]=testvalue2",
+// 		}
+// 		parsed, err := parseACLArguments(parsedArgs)
 
-		assert.Nil(t, err)
-		assert.Equal(t, "arg1", parsed["arg1"].Name)
-		assert.Equal(t, "testvalue1", parsed["arg1"].Value.([]string)[0])
-		assert.Equal(t, "testvalue2", parsed["arg1"].Value.([]string)[1])
-	})
-}
+// 		assert.Nil(t, err)
+// 		assert.Equal(t, "arg1", parsed["arg1"].Name)
+// 		assert.Equal(t, "testvalue1", parsed["arg1"].Value.([]string)[0])
+// 		assert.Equal(t, "testvalue2", parsed["arg1"].Value.([]string)[1])
+// 	})
+// }

--- a/cmd/loadbalancer/loadbalancer_acl_test.go
+++ b/cmd/loadbalancer/loadbalancer_acl_test.go
@@ -85,7 +85,8 @@ func Test_loadbalancerACLCreate(t *testing.T) {
 
 		service := mocks.NewMockLoadBalancerService(mockCtrl)
 		cmd := loadbalancerACLCreateCmd(nil)
-		cmd.ParseFlags([]string{"--name=testacl", "--mode=http"})
+		cmd.Flags().Set("name", "testacl")
+		cmd.Flags().Set("mode", "http")
 
 		req := loadbalancer.CreateACLRequest{
 			Name: "testacl",
@@ -105,7 +106,8 @@ func Test_loadbalancerACLCreate(t *testing.T) {
 
 		service := mocks.NewMockLoadBalancerService(mockCtrl)
 		cmd := loadbalancerACLCreateCmd(nil)
-		cmd.ParseFlags([]string{"--name=testacl", "--mode=http"})
+		cmd.Flags().Set("name", "testacl")
+		cmd.Flags().Set("mode", "http")
 
 		service.EXPECT().CreateACL(gomock.Any()).Return(0, errors.New("test error"))
 
@@ -120,7 +122,8 @@ func Test_loadbalancerACLCreate(t *testing.T) {
 
 		service := mocks.NewMockLoadBalancerService(mockCtrl)
 		cmd := loadbalancerACLCreateCmd(nil)
-		cmd.ParseFlags([]string{"--name=testacl", "--mode=http"})
+		cmd.Flags().Set("name", "testacl")
+		cmd.Flags().Set("mode", "http")
 
 		gomock.InOrder(
 			service.EXPECT().CreateACL(gomock.Any()).Return(123, nil),
@@ -156,7 +159,7 @@ func Test_loadbalancerACLUpdate(t *testing.T) {
 		service := mocks.NewMockLoadBalancerService(mockCtrl)
 
 		cmd := loadbalancerACLUpdateCmd(nil)
-		cmd.ParseFlags([]string{"--name=testacl"})
+		cmd.Flags().Set("name", "testacl")
 
 		req := loadbalancer.PatchACLRequest{
 			Name: "testacl",
@@ -271,82 +274,53 @@ func Test_loadbalancerACLDelete(t *testing.T) {
 	})
 }
 
-// func Test_parseACLStatementFlag(t *testing.T) {
-// 	t.Run("SingleArgumentExpectedReturnValue", func(t *testing.T) {
-// 		name, parsedArgs, err := parseACLStatementFlag("name1:arg1=testvalue1")
+func Test_parseACLArguments(t *testing.T) {
+	t.Run("SingleArgumentExpectedReturnValue", func(t *testing.T) {
+		parsedArgs := []string{
+			"arg1=testvalue1",
+		}
+		parsed, err := parseACLArguments(parsedArgs)
 
-// 		assert.Nil(t, err)
-// 		assert.Equal(t, "name1", name)
-// 		assert.Equal(t, "arg1", parsedArgs["arg1"].Name)
-// 		assert.Equal(t, "testvalue1", parsedArgs["arg1"].Value)
-// 	})
+		assert.Nil(t, err)
+		assert.Equal(t, "arg1", parsed["arg1"].Name)
+		assert.Equal(t, "testvalue1", parsed["arg1"].Value)
+	})
 
-// 	t.Run("MultipleArgumentsExpectedReturnValue", func(t *testing.T) {
-// 		name, parsedArgs, err := parseACLStatementFlag("name1:arg1=testvalue1,arg2=testvalue2")
+	t.Run("MultipleArgumentsExpectedReturnValue", func(t *testing.T) {
+		parsedArgs := []string{
+			"arg1=testvalue1",
+			"arg2=testvalue2",
+		}
+		parsed, err := parseACLArguments(parsedArgs)
 
-// 		assert.Nil(t, err)
-// 		assert.Equal(t, "name1", name)
-// 		assert.Equal(t, "arg1", parsedArgs["arg1"].Name)
-// 		assert.Equal(t, "testvalue1", parsedArgs["arg1"].Value)
-// 		assert.Equal(t, "arg2", parsedArgs["arg2"].Name)
-// 		assert.Equal(t, "testvalue2", parsedArgs["arg2"].Value)
-// 	})
+		assert.Nil(t, err)
+		assert.Equal(t, "arg1", parsed["arg1"].Name)
+		assert.Equal(t, "testvalue1", parsed["arg1"].Value)
+		assert.Equal(t, "arg2", parsed["arg2"].Name)
+		assert.Equal(t, "testvalue2", parsed["arg2"].Value)
+	})
 
-// 	t.Run("InvalidNameReturnsError", func(t *testing.T) {
-// 		_, _, err := parseACLStatementFlag("arg1=testvalue1,arg2=testvalue2")
+	t.Run("ArrayValueArgumentExpectedReturnValue", func(t *testing.T) {
+		parsedArgs := []string{
+			"arg1[]=testvalue1",
+		}
+		parsed, err := parseACLArguments(parsedArgs)
 
-// 		assert.NotNil(t, err)
-// 		assert.Equal(t, "invalid flag format. Expected format name:arguments", err.Error())
-// 	})
-// }
+		assert.Nil(t, err)
+		assert.Equal(t, "arg1", parsed["arg1"].Name)
+		assert.Equal(t, "testvalue1", parsed["arg1"].Value.([]string)[0])
+	})
 
-// func Test_parseACLArguments(t *testing.T) {
-// 	t.Run("SingleArgumentExpectedReturnValue", func(t *testing.T) {
-// 		parsedArgs := []string{
-// 			"arg1=testvalue1",
-// 		}
-// 		parsed, err := parseACLArguments(parsedArgs)
+	t.Run("MultipleArrayValueArgumentsExpectedReturnValue", func(t *testing.T) {
+		parsedArgs := []string{
+			"arg1[]=testvalue1",
+			"arg1[]=testvalue2",
+		}
+		parsed, err := parseACLArguments(parsedArgs)
 
-// 		assert.Nil(t, err)
-// 		assert.Equal(t, "arg1", parsed["arg1"].Name)
-// 		assert.Equal(t, "testvalue1", parsed["arg1"].Value)
-// 	})
-
-// 	t.Run("MultipleArgumentsExpectedReturnValue", func(t *testing.T) {
-// 		parsedArgs := []string{
-// 			"arg1=testvalue1",
-// 			"arg2=testvalue2",
-// 		}
-// 		parsed, err := parseACLArguments(parsedArgs)
-
-// 		assert.Nil(t, err)
-// 		assert.Equal(t, "arg1", parsed["arg1"].Name)
-// 		assert.Equal(t, "testvalue1", parsed["arg1"].Value)
-// 		assert.Equal(t, "arg2", parsed["arg2"].Name)
-// 		assert.Equal(t, "testvalue2", parsed["arg2"].Value)
-// 	})
-
-// 	t.Run("ArrayValueArgumentExpectedReturnValue", func(t *testing.T) {
-// 		parsedArgs := []string{
-// 			"arg1[]=testvalue1",
-// 		}
-// 		parsed, err := parseACLArguments(parsedArgs)
-
-// 		assert.Nil(t, err)
-// 		assert.Equal(t, "arg1", parsed["arg1"].Name)
-// 		assert.Equal(t, "testvalue1", parsed["arg1"].Value.([]string)[0])
-// 	})
-
-// 	t.Run("MultipleArrayValueArgumentsExpectedReturnValue", func(t *testing.T) {
-// 		parsedArgs := []string{
-// 			"arg1[]=testvalue1",
-// 			"arg1[]=testvalue2",
-// 		}
-// 		parsed, err := parseACLArguments(parsedArgs)
-
-// 		assert.Nil(t, err)
-// 		assert.Equal(t, "arg1", parsed["arg1"].Name)
-// 		assert.Equal(t, "testvalue1", parsed["arg1"].Value.([]string)[0])
-// 		assert.Equal(t, "testvalue2", parsed["arg1"].Value.([]string)[1])
-// 	})
-// }
+		assert.Nil(t, err)
+		assert.Equal(t, "arg1", parsed["arg1"].Name)
+		assert.Equal(t, "testvalue1", parsed["arg1"].Value.([]string)[0])
+		assert.Equal(t, "testvalue2", parsed["arg1"].Value.([]string)[1])
+	})
+}

--- a/cmd/loadbalancer/output.go
+++ b/cmd/loadbalancer/output.go
@@ -51,9 +51,20 @@ type ACLCondition struct {
 	Index int `json:"index"`
 }
 
-func OutputLoadBalancerACLConditionsProvider(acls []ACLCondition) output.OutputHandlerDataProvider {
-	return output.NewSerializedOutputHandlerDataProvider(acls).
+func OutputLoadBalancerACLConditionsProvider(conditions []ACLCondition) output.OutputHandlerDataProvider {
+	return output.NewSerializedOutputHandlerDataProvider(conditions).
 		WithDefaultFields([]string{"index", "name", "inverted", "arguments"})
+}
+
+// ACLAction represents an ACL action
+type ACLAction struct {
+	loadbalancer.ACLAction
+	Index int `json:"index"`
+}
+
+func OutputLoadBalancerACLActionsProvider(actions []ACLAction) output.OutputHandlerDataProvider {
+	return output.NewSerializedOutputHandlerDataProvider(actions).
+		WithDefaultFields([]string{"index", "name", "arguments"})
 }
 
 func OutputLoadBalancerACLTemplatesProvider(templates []loadbalancer.ACLTemplates) output.OutputHandlerDataProvider {

--- a/cmd/loadbalancer/output.go
+++ b/cmd/loadbalancer/output.go
@@ -45,6 +45,17 @@ func OutputLoadBalancerACLsProvider(acls []loadbalancer.ACL) output.OutputHandle
 		WithDefaultFields([]string{"id", "name", "conditions", "actions"})
 }
 
+// ACLCondition represents an ACL condition
+type ACLCondition struct {
+	loadbalancer.ACLCondition
+	Index int `json:"index"`
+}
+
+func OutputLoadBalancerACLConditionsProvider(acls []ACLCondition) output.OutputHandlerDataProvider {
+	return output.NewSerializedOutputHandlerDataProvider(acls).
+		WithDefaultFields([]string{"index", "name", "inverted", "arguments"})
+}
+
 func OutputLoadBalancerACLTemplatesProvider(templates []loadbalancer.ACLTemplates) output.OutputHandlerDataProvider {
 	return output.NewSerializedOutputHandlerDataProvider(templates).
 		WithDefaultFields([]string{"id", "conditions", "actions"})


### PR DESCRIPTION
Reworks ACL commands to allow working with specific conditions/actions via subcommands.

This is a breaking change - we are only allowing a single argument and action on create, with subsequent actions requiring use of new subcommands.