### PR TITLE
Support vCPU socket/cores per socket options for instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cover.out
 dist/
 __debug_bin
 cli
+/.idea

--- a/cmd/ecloud/output.go
+++ b/cmd/ecloud/output.go
@@ -325,7 +325,7 @@ func OutputECloudVPCsProvider(vpcs []ecloud.VPC) output.OutputHandlerDataProvide
 }
 
 func OutputECloudInstancesProvider(instances []ecloud.Instance) output.OutputHandlerDataProvider {
-	return output.NewSerializedOutputHandlerDataProvider(instances).WithDefaultFields([]string{"id", "name", "vpc_id", "vcpu_cores", "ram_capacity", "sync_status"})
+	return output.NewSerializedOutputHandlerDataProvider(instances).WithDefaultFields([]string{"id", "name", "vpc_id", "vcpu_sockets", "vcpu_cores_per_socket", "ram_capacity", "sync_status"})
 }
 
 func OutputECloudFloatingIPsProvider(fips []ecloud.FloatingIP) output.OutputHandlerDataProvider {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ans-group/cli
 go 1.18
 
 require (
-	github.com/ans-group/sdk-go v1.16.10
+	github.com/ans-group/sdk-go v1.16.11
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/golang/mock v1.6.0
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ans-group/go-durationstring v1.2.0 h1:UJIuQATkp0t1rBvZsHRwki33YHV9E+Ulro+3NbMB7MM=
 github.com/ans-group/go-durationstring v1.2.0/go.mod h1:QGF9Mdpq9058QXaut8r55QWu6lcHX6i/GvF1PZVkV6o=
-github.com/ans-group/sdk-go v1.16.10 h1:zdxXN/gqxFQWFCoIeQahPnz/Nj9OfGyuJ7RGJYFBDr8=
-github.com/ans-group/sdk-go v1.16.10/go.mod h1:p1vrXBxHPvMOGlS4sFUSgeLeKAl9vIe/lJ6UaExe49A=
+github.com/ans-group/sdk-go v1.16.11 h1:xc064+wx8RI/vcoRHKkM9iMrBjOtt9y3KChXpme0ZaI=
+github.com/ans-group/sdk-go v1.16.11/go.mod h1:p1vrXBxHPvMOGlS4sFUSgeLeKAl9vIe/lJ6UaExe49A=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=


### PR DESCRIPTION
Adds `--vcpu-sockets` and `--vcpu-cores-per-socket` flags to VPC instance creation/update.

Deprecates `--vcpu` option which will no longer show up in `--help` and print a warning when used.

