### PR TITLE
Support CRUD operations on tags for instances

### DIFF
--- a/cmd/ecloud/ecloud_instance.go
+++ b/cmd/ecloud/ecloud_instance.go
@@ -275,7 +275,7 @@ func ecloudInstanceUpdateCmd(f factory.ClientFactory) *cobra.Command {
 	cmd.Flags().String("volume-group", "", "ID of volume-group to use for instance")
 	cmd.Flags().StringSlice("set-tag", []string{}, "Tag in the form of '<scope>:<name>', '<name>' or a tag ID to apply to the instance, use an empty string to clear all existing tags - overwrites existing tags")
 	cmd.Flags().StringSlice("add-tag", []string{}, "Tag (like --set-tag) to add to the instance, keeping existing tags intact, can be repeated")
-	cmd.Flags().StringSlice("remove-tag", []string{}, "Tag (like --set-tag) to remove to the instance, without removing other tags, can be repeated")
+	cmd.Flags().StringSlice("remove-tag", []string{}, "Tag (like --set-tag) to remove from the instance, without removing other tags, can be repeated")
 	cmd.Flags().Bool("wait", false, "Specifies that the command should wait until the instance has been completely updated")
 
 	return cmd

--- a/cmd/ecloud/ecloud_instance.go
+++ b/cmd/ecloud/ecloud_instance.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -144,6 +145,7 @@ func ecloudInstanceCreateCmd(f factory.ClientFactory) *cobra.Command {
 	cmd.Flags().String("backup-gateway-id", "", "Backup gateway ID, enables agent-level backups")
 	cmd.Flags().Bool("enable-monitoring", false, "Enable monitoring")
 	cmd.Flags().String("monitoring-gateway-id", "", "Monitoring gateway ID")
+	cmd.Flags().StringSlice("tag", []string{}, "Tag in form '<scope>:<name>', '<name>' or tag ID to apply to the instance, can be repeated")
 	cmd.Flags().Bool("wait", false, "Specifies that the command should wait until the instance has been completely created")
 
 	return cmd
@@ -180,6 +182,19 @@ func ecloudInstanceCreate(service ecloud.ECloudService, cmd *cobra.Command, args
 	if cmd.Flags().Changed("ip-address") {
 		ipAddress, _ := cmd.Flags().GetString("ip-address")
 		createRequest.CustomIPAddress = connection.IPAddress(ipAddress)
+	}
+
+	if cmd.Flags().Changed("tag") {
+		var tagIDs []string
+		tagsArg, _ := cmd.Flags().GetStringSlice("tag")
+		for _, tag := range tagsArg {
+			tagID, err := tagLookup(service, tag)
+			if err != nil {
+				return err
+			}
+			tagIDs = append(tagIDs, tagID)
+		}
+		createRequest.TagIDs = tagIDs
 	}
 
 	imageFlag, _ := cmd.Flags().GetString("image")
@@ -258,6 +273,9 @@ func ecloudInstanceUpdateCmd(f factory.ClientFactory) *cobra.Command {
 	cmd.Flags().Int("vcpu-cores-per-socket", 0, "Number of vCPU cores to allocate per socket")
 	cmd.Flags().Int("ram", 0, "Amount of RAM (in MB) to allocate")
 	cmd.Flags().String("volume-group", "", "ID of volume-group to use for instance")
+	cmd.Flags().StringSlice("set-tag", []string{}, "Tag in the form of '<scope>:<name>', '<name>' or a tag ID to apply to the instance, use an empty string to clear all existing tags - overwrites existing tags")
+	cmd.Flags().StringSlice("add-tag", []string{}, "Tag (like --set-tag) to add to the instance, keeping existing tags intact, can be repeated")
+	cmd.Flags().StringSlice("remove-tag", []string{}, "Tag (like --set-tag) to remove to the instance, without removing other tags, can be repeated")
 	cmd.Flags().Bool("wait", false, "Specifies that the command should wait until the instance has been completely updated")
 
 	return cmd
@@ -292,6 +310,45 @@ func ecloudInstanceUpdate(service ecloud.ECloudService, cmd *cobra.Command, args
 	if cmd.Flags().Changed("volume-group") {
 		volGroup, _ := cmd.Flags().GetString("volume-group")
 		patchRequest.VolumeGroupID = ptr.String(volGroup)
+	}
+
+	if cmd.Flags().Changed("set-tag") {
+		tagsArg, _ := cmd.Flags().GetStringSlice("set-tag")
+		if len(tagsArg) == 0 || (len(tagsArg) == 1 && tagsArg[0] == "") {
+			// Clear all existing tags by setting to empty array
+			emptyTags := []string{}
+			patchRequest.TagIDs = &emptyTags
+		} else {
+			var tagIDs []string
+			for _, tag := range tagsArg {
+				tagID, err := tagLookup(service, tag)
+				if err != nil {
+					return err
+				}
+				tagIDs = append(tagIDs, tagID)
+			}
+			patchRequest.TagIDs = &tagIDs
+		}
+	}
+
+	if cmd.Flags().Changed("add-tag") {
+		addTagsArg, _ := cmd.Flags().GetStringSlice("add-tag")
+		for _, arg := range args {
+			err := addRemoveTags(service, &patchRequest, arg, addTagsArg, true)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if cmd.Flags().Changed("remove-tag") {
+		removeTagsArg, _ := cmd.Flags().GetStringSlice("remove-tag")
+		for _, arg := range args {
+			err := addRemoveTags(service, &patchRequest, arg, removeTagsArg, false)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	var instances []ecloud.Instance
@@ -793,4 +850,107 @@ func InstanceNotFoundWaitFunc(service ecloud.ECloudService, instanceID string) h
 
 		return false, nil
 	}
+}
+
+func tagLookup(service ecloud.ECloudService, tag string) (string, error) {
+	if tag == "" {
+		return "", fmt.Errorf("Cannot lookup tag with empty value")
+	}
+
+	if strings.HasPrefix(tag, "tag-") {
+		return tag, nil
+	}
+
+	var filter []connection.APIRequestFiltering
+	if strings.Contains(tag, ":") {
+		parts := strings.Split(tag, ":")
+		if len(parts) != 2 {
+			return "", fmt.Errorf("Invalid tag format '%s', expected '<scope>:<name>'", tag)
+		}
+		filter = []connection.APIRequestFiltering{
+			{
+				Property: "scope",
+				Operator: connection.EQOperator,
+				Value:    []string{parts[0]},
+			},
+			{
+				Property: "name",
+				Operator: connection.EQOperator,
+				Value:    []string{parts[1]},
+			},
+		}
+	} else {
+		filter = []connection.APIRequestFiltering{
+			{
+				Property: "name",
+				Operator: connection.EQOperator,
+				Value:    []string{tag},
+			},
+		}
+	}
+
+	tags, err := service.GetTags(connection.APIRequestParameters{
+		Filtering: filter,
+	})
+	if err != nil {
+		return "", fmt.Errorf("Error retrieving tags: %s", err)
+	}
+
+	if len(tags) == 0 {
+		return "", fmt.Errorf("Tag '%s' not found, create the tag first", tag)
+	}
+
+	if len(tags) > 1 {
+		var foundTags []string
+		for _, t := range tags {
+			foundTags = append(foundTags, fmt.Sprintf("%s (%s:%s)", t.ID, t.Scope, t.Name))
+		}
+		return "", fmt.Errorf("Expected 1 tag, got %d tags with matching scope/name: %s", len(tags), strings.Join(foundTags, ", "))
+	}
+
+	return tags[0].ID, nil
+}
+
+func addRemoveTags(service ecloud.ECloudService, request *ecloud.PatchInstanceRequest, instanceID string, tags []string, add bool) error {
+	currentTags := make(map[string]bool)
+	if request.TagIDs != nil {
+		for _, id := range *request.TagIDs {
+			currentTags[id] = true
+		}
+	} else {
+		instance, err := service.GetInstance(instanceID)
+		if err != nil {
+			return fmt.Errorf("Error retrieving instance tags [%s]: %s", instanceID, err)
+		}
+		for _, tag := range instance.Tags {
+			currentTags[tag.ID] = true
+		}
+	}
+
+	for _, tag := range tags {
+		tag = strings.TrimSpace(tag)
+		if tag == "" {
+			continue
+		}
+
+		tagID, err := tagLookup(service, tag)
+		if err != nil {
+			return err
+		}
+
+		if add {
+			currentTags[tagID] = true
+		} else {
+			delete(currentTags, tagID)
+		}
+	}
+
+	finalTags := make([]string, 0, len(currentTags))
+	for id := range currentTags {
+		finalTags = append(finalTags, id)
+	}
+	sort.Strings(finalTags)
+
+	request.TagIDs = &finalTags
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.5
 
 require (
-	github.com/ans-group/sdk-go v1.24.0
+	github.com/ans-group/sdk-go v1.25.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/golang/mock v1.6.0
 	github.com/iancoleman/strcase v0.3.0
@@ -64,4 +64,4 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
 
-// replace github.com/ans-group/sdk-go => ../sdk-go
+//replace github.com/ans-group/sdk-go => ../sdk-go

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/ans-group/go-durationstring v1.2.0 h1:UJIuQATkp0t1rBvZsHRwki33YHV9E+Ulro+3NbMB7MM=
 github.com/ans-group/go-durationstring v1.2.0/go.mod h1:QGF9Mdpq9058QXaut8r55QWu6lcHX6i/GvF1PZVkV6o=
-github.com/ans-group/sdk-go v1.24.0 h1:EXiwo2bk/ZrIT0nR1ZPBh+WcBW9rloaXptEzTsa0Qvc=
-github.com/ans-group/sdk-go v1.24.0/go.mod h1:Dx34ZUbyHNniHAKsDy/vp8q8hQC5L51ub2sv9We7d8E=
+github.com/ans-group/sdk-go v1.25.0 h1:aPQKSvLhnpdx8qwXAMz0YV9UX2hp4uD39g+44/S33RU=
+github.com/ans-group/sdk-go v1.25.0/go.mod h1:Dx34ZUbyHNniHAKsDy/vp8q8hQC5L51ub2sv9We7d8E=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -54,7 +54,6 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -65,8 +64,6 @@ github.com/olekukonko/errors v1.1.0 h1:RNuGIh15QdDenh+hNvKrJkmxxjV4hcS50Db478Ou5
 github.com/olekukonko/errors v1.1.0/go.mod h1:ppzxA5jBKcO1vIpCXQ9ZqgDh8iwODz6OXIGKU8r5m4Y=
 github.com/olekukonko/ll v0.0.9 h1:Y+1YqDfVkqMWuEQMclsF9HUR5+a82+dxJuL1HHSRpxI=
 github.com/olekukonko/ll v0.0.9/go.mod h1:En+sEW0JNETl26+K8eZ6/W4UQ7CYSrrgg/EdIYT2H8g=
-github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
-github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/olekukonko/tablewriter v1.0.9 h1:XGwRsYLC2bY7bNd93Dk51bcPZksWZmLYuaTHR0FqfL8=
 github.com/olekukonko/tablewriter v1.0.9/go.mod h1:5c+EBPeSqvXnLLgkm9isDdzR3wjfBkHR9Nhfp3NWrzo=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
Adds support for CRUD operations on instances.

For `ecloud instance create`:

```
--tag strings                    Tag in form '<scope>:<name>', '<name>' or tag ID to apply to the instance, can be repeated
```

For `ecloud instance update`:

```
--set-tag strings             Tag in the form of '<scope>:<name>', '<name>' or a tag ID to apply to the instance, use an empty string to clear all existing tags - overwrites existing tags
--remove-tag strings          Tag (like --set-tag) to remove from the instance, without removing other tags, can be repeated
--add-tag strings             Tag (like --set-tag) to add to the instance, keeping existing tags intact, can be repeated
```
