### PR TITLE
Add tag management commands

### DIFF
--- a/cmd/ecloud/ecloud.go
+++ b/cmd/ecloud/ecloud.go
@@ -61,6 +61,7 @@ func ECloudRootCmd(f factory.ClientFactory, fs afero.Fs) *cobra.Command {
 		cmd.AddCommand(ecloudRouterRootCmd(f))
 		cmd.AddCommand(ecloudRouterThroughputRootCmd(f))
 		cmd.AddCommand(ecloudSSHKeyPairRootCmd(f, fs))
+		cmd.AddCommand(ecloudTagRootCmd(f))
 		cmd.AddCommand(ecloudTaskRootCmd(f))
 		cmd.AddCommand(ecloudVIPRootCmd(f))
 		cmd.AddCommand(ecloudVolumeRootCmd(f))

--- a/cmd/ecloud/ecloud_tag.go
+++ b/cmd/ecloud/ecloud_tag.go
@@ -1,0 +1,211 @@
+package ecloud
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ans-group/cli/internal/pkg/factory"
+	"github.com/ans-group/cli/internal/pkg/helper"
+	"github.com/ans-group/cli/internal/pkg/output"
+	"github.com/ans-group/sdk-go/pkg/service/ecloud"
+	"github.com/spf13/cobra"
+)
+
+func ecloudTagRootCmd(f factory.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tag",
+		Short: "sub-commands relating to tags",
+	}
+
+	// Child commands
+	cmd.AddCommand(ecloudTagListCmd(f))
+	cmd.AddCommand(ecloudTagShowCmd(f))
+	cmd.AddCommand(ecloudTagCreateCmd(f))
+	cmd.AddCommand(ecloudTagUpdateCmd(f))
+	cmd.AddCommand(ecloudTagDeleteCmd(f))
+
+	return cmd
+}
+
+func ecloudTagListCmd(f factory.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "Lists tags",
+		Long:    "This command lists tags",
+		Example: "ans ecloud tag list",
+		RunE:    ecloudCobraRunEFunc(f, ecloudTagList),
+	}
+
+	cmd.Flags().String("name", "", "Tag name for filtering")
+	cmd.Flags().String("scope", "", "Tag scope for filtering")
+
+	return cmd
+}
+
+func ecloudTagList(service ecloud.ECloudService, cmd *cobra.Command, args []string) error {
+	params, err := helper.GetAPIRequestParametersFromFlags(cmd,
+		helper.NewStringFilterFlagOption("name", "name"),
+		helper.NewStringFilterFlagOption("scope", "scope"),
+	)
+	if err != nil {
+		return err
+	}
+
+	tags, err := service.GetTags(params)
+	if err != nil {
+		return fmt.Errorf("ecloud: Error retrieving tags: %s", err)
+	}
+
+	return output.CommandOutput(cmd, TagCollection(tags))
+}
+
+func ecloudTagShowCmd(f factory.ClientFactory) *cobra.Command {
+	return &cobra.Command{
+		Use:     "show <tag: id>...",
+		Short:   "Shows a tag",
+		Long:    "This command shows one or more tags",
+		Example: "ans ecloud tag show tag-abcdef12",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("Missing tag")
+			}
+
+			return nil
+		},
+		RunE: ecloudCobraRunEFunc(f, ecloudTagShow),
+	}
+}
+
+func ecloudTagShow(service ecloud.ECloudService, cmd *cobra.Command, args []string) error {
+	var tags []ecloud.Tag
+	for _, arg := range args {
+		tag, err := service.GetTag(arg)
+		if err != nil {
+			output.OutputWithErrorLevelf("Error retrieving tag [%s]: %s", arg, err)
+			continue
+		}
+
+		tags = append(tags, tag)
+	}
+
+	return output.CommandOutput(cmd, TagCollection(tags))
+}
+
+func ecloudTagCreateCmd(f factory.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "create",
+		Short:   "Creates a tag",
+		Long:    "This command creates a tag",
+		Example: "ans ecloud tag create --name \"production\" --scope \"environment\"",
+		RunE:    ecloudCobraRunEFunc(f, ecloudTagCreate),
+	}
+
+	// Setup flags
+	cmd.Flags().String("name", "", "Name of tag")
+	cmd.MarkFlagRequired("name")
+	cmd.Flags().String("scope", "", "Scope of tag")
+	cmd.MarkFlagRequired("scope")
+
+	return cmd
+}
+
+func ecloudTagCreate(service ecloud.ECloudService, cmd *cobra.Command, args []string) error {
+	createRequest := ecloud.CreateTagRequest{}
+	createRequest.Name, _ = cmd.Flags().GetString("name")
+	createRequest.Scope, _ = cmd.Flags().GetString("scope")
+
+	tagID, err := service.CreateTag(createRequest)
+	if err != nil {
+		return fmt.Errorf("ecloud: Error creating tag: %s", err)
+	}
+
+	tag, err := service.GetTag(tagID)
+	if err != nil {
+		return fmt.Errorf("ecloud: Error retrieving new tag: %s", err)
+	}
+
+	return output.CommandOutput(cmd, TagCollection([]ecloud.Tag{tag}))
+}
+
+func ecloudTagUpdateCmd(f factory.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "update <tag: id>...",
+		Short:   "Updates a tag",
+		Long:    "This command updates one or more tags",
+		Example: "ans ecloud tag update tag-abcdef12 --name \"staging\"",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("Missing tag")
+			}
+
+			return nil
+		},
+		RunE: ecloudCobraRunEFunc(f, ecloudTagUpdate),
+	}
+
+	cmd.Flags().String("name", "", "Name of tag")
+	cmd.Flags().String("scope", "", "Scope of tag")
+
+	return cmd
+}
+
+func ecloudTagUpdate(service ecloud.ECloudService, cmd *cobra.Command, args []string) error {
+	patchRequest := ecloud.PatchTagRequest{}
+
+	if cmd.Flags().Changed("name") {
+		patchRequest.Name, _ = cmd.Flags().GetString("name")
+	}
+
+	if cmd.Flags().Changed("scope") {
+		patchRequest.Scope, _ = cmd.Flags().GetString("scope")
+	}
+
+	var tags []ecloud.Tag
+	for _, arg := range args {
+		err := service.PatchTag(arg, patchRequest)
+		if err != nil {
+			output.OutputWithErrorLevelf("Error updating tag [%s]: %s", arg, err)
+			continue
+		}
+
+		tag, err := service.GetTag(arg)
+		if err != nil {
+			output.OutputWithErrorLevelf("Error retrieving updated tag [%s]: %s", arg, err)
+			continue
+		}
+
+		tags = append(tags, tag)
+	}
+
+	return output.CommandOutput(cmd, TagCollection(tags))
+}
+
+func ecloudTagDeleteCmd(f factory.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete <tag: id>...",
+		Short:   "Removes a tag",
+		Long:    "This command removes one or more tags",
+		Example: "ans ecloud tag delete tag-abcdef12",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("Missing tag")
+			}
+
+			return nil
+		},
+		RunE: ecloudCobraRunEFunc(f, ecloudTagDelete),
+	}
+
+	return cmd
+}
+
+func ecloudTagDelete(service ecloud.ECloudService, cmd *cobra.Command, args []string) error {
+	for _, arg := range args {
+		err := service.DeleteTag(arg)
+		if err != nil {
+			output.OutputWithErrorLevelf("Error removing tag [%s]: %s", arg, err)
+			continue
+		}
+	}
+	return nil
+}

--- a/cmd/ecloud/ecloud_tag_test.go
+++ b/cmd/ecloud/ecloud_tag_test.go
@@ -1,0 +1,309 @@
+package ecloud
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ans-group/cli/internal/pkg/clierrors"
+	"github.com/ans-group/cli/test/mocks"
+	"github.com/ans-group/sdk-go/pkg/service/ecloud"
+	gomock "github.com/golang/mock/gomock"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ecloudTagList(t *testing.T) {
+	t.Run("DefaultRetrieve", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+
+		service.EXPECT().GetTags(gomock.Any()).Return([]ecloud.Tag{}, nil).Times(1)
+
+		ecloudTagList(service, &cobra.Command{}, []string{})
+	})
+
+	t.Run("MalformedFlag_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+		cmd := &cobra.Command{}
+		cmd.Flags().StringArray("filter", []string{"invalidfilter"}, "")
+
+		err := ecloudTagList(service, cmd, []string{})
+
+		assert.IsType(t, &clierrors.ErrInvalidFlagValue{}, err)
+	})
+
+	t.Run("GetTagsError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+
+		service.EXPECT().GetTags(gomock.Any()).Return([]ecloud.Tag{}, errors.New("test error")).Times(1)
+
+		err := ecloudTagList(service, &cobra.Command{}, []string{})
+
+		assert.Equal(t, "ecloud: Error retrieving tags: test error", err.Error())
+	})
+}
+
+func Test_ecloudTagShowCmd_Args(t *testing.T) {
+	t.Run("ValidArgs_NoError", func(t *testing.T) {
+		err := ecloudTagShowCmd(nil).Args(nil, []string{"tag-abcdef12"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("InvalidArgs_Error", func(t *testing.T) {
+		err := ecloudTagShowCmd(nil).Args(nil, []string{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing tag", err.Error())
+	})
+}
+
+func Test_ecloudTagShow(t *testing.T) {
+	t.Run("SingleTag", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+
+		service.EXPECT().GetTag("tag-abcdef12").Return(ecloud.Tag{}, nil).Times(1)
+
+		ecloudTagShow(service, &cobra.Command{}, []string{"tag-abcdef12"})
+	})
+
+	t.Run("MultipleTags", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+
+		gomock.InOrder(
+			service.EXPECT().GetTag("tag-abcdef12").Return(ecloud.Tag{}, nil),
+			service.EXPECT().GetTag("tag-abcdef23").Return(ecloud.Tag{}, nil),
+		)
+
+		ecloudTagShow(service, &cobra.Command{}, []string{"tag-abcdef12", "tag-abcdef23"})
+	})
+
+	t.Run("GetTagError_OutputsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+
+		service.EXPECT().GetTag("tag-abcdef12").Return(ecloud.Tag{}, errors.New("test error")).Times(1)
+
+		ecloudTagShow(service, &cobra.Command{}, []string{"tag-abcdef12"})
+	})
+}
+
+func Test_ecloudTagCreate(t *testing.T) {
+	t.Run("DefaultCreate", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+		cmd := ecloudTagCreateCmd(nil)
+		cmd.Flags().Set("name", "production")
+		cmd.Flags().Set("scope", "environment")
+
+		expectedRequest := ecloud.CreateTagRequest{
+			Name:  "production",
+			Scope: "environment",
+		}
+
+		gomock.InOrder(
+			service.EXPECT().CreateTag(expectedRequest).Return("tag-abcdef12", nil),
+			service.EXPECT().GetTag("tag-abcdef12").Return(ecloud.Tag{}, nil),
+		)
+
+		ecloudTagCreate(service, cmd, []string{})
+	})
+
+	t.Run("CreateTagError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+		cmd := ecloudTagCreateCmd(nil)
+		cmd.Flags().Set("name", "production")
+		cmd.Flags().Set("scope", "environment")
+
+		service.EXPECT().CreateTag(gomock.Any()).Return("", errors.New("test error")).Times(1)
+
+		err := ecloudTagCreate(service, cmd, []string{})
+
+		assert.Equal(t, "ecloud: Error creating tag: test error", err.Error())
+	})
+
+	t.Run("GetTagError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+		cmd := ecloudTagCreateCmd(nil)
+		cmd.Flags().Set("name", "production")
+		cmd.Flags().Set("scope", "environment")
+
+		gomock.InOrder(
+			service.EXPECT().CreateTag(gomock.Any()).Return("tag-abcdef12", nil),
+			service.EXPECT().GetTag("tag-abcdef12").Return(ecloud.Tag{}, errors.New("test error")),
+		)
+
+		err := ecloudTagCreate(service, cmd, []string{})
+
+		assert.Equal(t, "ecloud: Error retrieving new tag: test error", err.Error())
+	})
+}
+
+func Test_ecloudTagUpdateCmd_Args(t *testing.T) {
+	t.Run("ValidArgs_NoError", func(t *testing.T) {
+		err := ecloudTagUpdateCmd(nil).Args(nil, []string{"tag-abcdef12"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("InvalidArgs_Error", func(t *testing.T) {
+		err := ecloudTagUpdateCmd(nil).Args(nil, []string{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing tag", err.Error())
+	})
+}
+
+func Test_ecloudTagUpdate(t *testing.T) {
+	t.Run("SingleTag", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+
+		cmd := ecloudTagUpdateCmd(nil)
+		cmd.Flags().Set("name", "staging")
+
+		expectedRequest := ecloud.PatchTagRequest{
+			Name: "staging",
+		}
+
+		gomock.InOrder(
+			service.EXPECT().PatchTag("tag-abcdef12", expectedRequest).Return(nil),
+			service.EXPECT().GetTag("tag-abcdef12").Return(ecloud.Tag{}, nil),
+		)
+
+		ecloudTagUpdate(service, cmd, []string{"tag-abcdef12"})
+	})
+
+	t.Run("MultipleTags", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+
+		cmd := ecloudTagUpdateCmd(nil)
+		cmd.Flags().Set("name", "staging")
+
+		expectedRequest := ecloud.PatchTagRequest{
+			Name: "staging",
+		}
+
+		gomock.InOrder(
+			service.EXPECT().PatchTag("tag-abcdef12", expectedRequest).Return(nil),
+			service.EXPECT().GetTag("tag-abcdef12").Return(ecloud.Tag{}, nil),
+			service.EXPECT().PatchTag("tag-abcdef23", expectedRequest).Return(nil),
+			service.EXPECT().GetTag("tag-abcdef23").Return(ecloud.Tag{}, nil),
+		)
+
+		ecloudTagUpdate(service, cmd, []string{"tag-abcdef12", "tag-abcdef23"})
+	})
+
+	t.Run("PatchTagError_OutputsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+
+		cmd := ecloudTagUpdateCmd(nil)
+		cmd.Flags().Set("name", "staging")
+
+		service.EXPECT().PatchTag("tag-abcdef12", gomock.Any()).Return(errors.New("test error")).Times(1)
+
+		ecloudTagUpdate(service, cmd, []string{"tag-abcdef12"})
+	})
+
+	t.Run("GetTagError_OutputsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+
+		cmd := ecloudTagUpdateCmd(nil)
+		cmd.Flags().Set("name", "staging")
+
+		gomock.InOrder(
+			service.EXPECT().PatchTag("tag-abcdef12", gomock.Any()).Return(nil),
+			service.EXPECT().GetTag("tag-abcdef12").Return(ecloud.Tag{}, errors.New("test error")),
+		)
+
+		ecloudTagUpdate(service, cmd, []string{"tag-abcdef12"})
+	})
+}
+
+func Test_ecloudTagDeleteCmd_Args(t *testing.T) {
+	t.Run("ValidArgs_NoError", func(t *testing.T) {
+		err := ecloudTagDeleteCmd(nil).Args(nil, []string{"tag-abcdef12"})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("InvalidArgs_Error", func(t *testing.T) {
+		err := ecloudTagDeleteCmd(nil).Args(nil, []string{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Missing tag", err.Error())
+	})
+}
+
+func Test_ecloudTagDelete(t *testing.T) {
+	t.Run("SingleTag", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+
+		service.EXPECT().DeleteTag("tag-abcdef12").Return(nil).Times(1)
+
+		ecloudTagDelete(service, &cobra.Command{}, []string{"tag-abcdef12"})
+	})
+
+	t.Run("MultipleTags", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+
+		gomock.InOrder(
+			service.EXPECT().DeleteTag("tag-abcdef12").Return(nil),
+			service.EXPECT().DeleteTag("tag-abcdef23").Return(nil),
+		)
+
+		ecloudTagDelete(service, &cobra.Command{}, []string{"tag-abcdef12", "tag-abcdef23"})
+	})
+
+	t.Run("DeleteTagError_OutputsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+
+		service.EXPECT().DeleteTag("tag-abcdef12").Return(errors.New("test error")).Times(1)
+
+		ecloudTagDelete(service, &cobra.Command{}, []string{"tag-abcdef12"})
+	})
+}

--- a/cmd/ecloud/ecloud_v1_solution_tag.go
+++ b/cmd/ecloud/ecloud_v1_solution_tag.go
@@ -69,7 +69,7 @@ func ecloudSolutionTagList(service ecloud.ECloudService, cmd *cobra.Command, arg
 		return fmt.Errorf("Error retrieving solution tags: %s", err)
 	}
 
-	return output.CommandOutput(cmd, TagCollection(tags))
+	return output.CommandOutput(cmd, TagV1Collection(tags))
 }
 
 func ecloudSolutionTagShowCmd(f factory.ClientFactory) *cobra.Command {
@@ -117,7 +117,7 @@ func ecloudSolutionTagShow(service ecloud.ECloudService, cmd *cobra.Command, arg
 		tags = append(tags, tag)
 	}
 
-	return output.CommandOutput(cmd, TagCollection(tags))
+	return output.CommandOutput(cmd, TagV1Collection(tags))
 }
 
 func ecloudSolutionTagCreateCmd(f factory.ClientFactory) *cobra.Command {
@@ -175,7 +175,7 @@ func ecloudSolutionTagCreate(service ecloud.ECloudService, cmd *cobra.Command, a
 		return fmt.Errorf("Error retrieving new solution tag: %s", err)
 	}
 
-	return output.CommandOutput(cmd, TagCollection([]ecloud.TagV1{tag}))
+	return output.CommandOutput(cmd, TagV1Collection([]ecloud.TagV1{tag}))
 }
 
 func ecloudSolutionTagUpdateCmd(f factory.ClientFactory) *cobra.Command {
@@ -240,7 +240,7 @@ func ecloudSolutionTagUpdate(service ecloud.ECloudService, cmd *cobra.Command, a
 		tags = append(tags, tag)
 	}
 
-	return output.CommandOutput(cmd, TagCollection(tags))
+	return output.CommandOutput(cmd, TagV1Collection(tags))
 }
 
 func ecloudSolutionTagDeleteCmd(f factory.ClientFactory) *cobra.Command {

--- a/cmd/ecloud/ecloud_v1_vm_tag.go
+++ b/cmd/ecloud/ecloud_v1_vm_tag.go
@@ -69,7 +69,7 @@ func ecloudVirtualMachineTagList(service ecloud.ECloudService, cmd *cobra.Comman
 		return fmt.Errorf("Error retrieving virtual machine tags: %s", err)
 	}
 
-	return output.CommandOutput(cmd, TagCollection(tags))
+	return output.CommandOutput(cmd, TagV1Collection(tags))
 }
 
 func ecloudVirtualMachineTagShowCmd(f factory.ClientFactory) *cobra.Command {
@@ -117,7 +117,7 @@ func ecloudVirtualMachineTagShow(service ecloud.ECloudService, cmd *cobra.Comman
 		tags = append(tags, tag)
 	}
 
-	return output.CommandOutput(cmd, TagCollection(tags))
+	return output.CommandOutput(cmd, TagV1Collection(tags))
 }
 
 func ecloudVirtualMachineTagCreateCmd(f factory.ClientFactory) *cobra.Command {
@@ -175,7 +175,7 @@ func ecloudVirtualMachineTagCreate(service ecloud.ECloudService, cmd *cobra.Comm
 		return fmt.Errorf("Error retrieving new virtual machine tag: %s", err)
 	}
 
-	return output.CommandOutput(cmd, TagCollection([]ecloud.TagV1{tag}))
+	return output.CommandOutput(cmd, TagV1Collection([]ecloud.TagV1{tag}))
 }
 
 func ecloudVirtualMachineTagUpdateCmd(f factory.ClientFactory) *cobra.Command {
@@ -240,7 +240,7 @@ func ecloudVirtualMachineTagUpdate(service ecloud.ECloudService, cmd *cobra.Comm
 		tags = append(tags, tag)
 	}
 
-	return output.CommandOutput(cmd, TagCollection(tags))
+	return output.CommandOutput(cmd, TagV1Collection(tags))
 }
 
 func ecloudVirtualMachineTagDeleteCmd(f factory.ClientFactory) *cobra.Command {

--- a/cmd/ecloud/output.go
+++ b/cmd/ecloud/output.go
@@ -67,13 +67,13 @@ func (m VirtualMachineDiskCollection) Fields() []*output.OrderedFields {
 	return data
 }
 
-type TagCollection []ecloud.TagV1
+type TagV1Collection []ecloud.TagV1
 
-func (m TagCollection) DefaultColumns() []string {
+func (m TagV1Collection) DefaultColumns() []string {
 	return []string{"key", "value", "created_at"}
 }
 
-func (m TagCollection) Fields() []*output.OrderedFields {
+func (m TagV1Collection) Fields() []*output.OrderedFields {
 	var data []*output.OrderedFields
 	for _, tag := range m {
 		fields := output.NewOrderedFields()
@@ -614,4 +614,25 @@ type BackupGatewayCollection []ecloud.BackupGateway
 
 func (m BackupGatewayCollection) DefaultColumns() []string {
 	return []string{"id", "name", "vpc_id", "availability_zone", "gateway_spec_id", "sync_status"}
+}
+
+type TagCollection []ecloud.Tag
+
+func (m TagCollection) DefaultColumns() []string {
+	return []string{"id", "name", "scope", "created_at"}
+}
+
+func (m TagCollection) Fields() []*output.OrderedFields {
+	var data []*output.OrderedFields
+	for _, tag := range m {
+		fields := output.NewOrderedFields()
+		fields.Set("id", tag.ID)
+		fields.Set("scope", tag.Scope)
+		fields.Set("name", tag.Name)
+		fields.Set("created_at", tag.CreatedAt.String())
+
+		data = append(data, fields)
+	}
+
+	return data
 }


### PR DESCRIPTION
```
❯ ./ans ecloud tag
sub-commands relating to tags

Usage:
  ans ecloud tag [command]

Available Commands:
  create      Creates a tag
  delete      Removes a tag
  list        Lists tags
  show        Shows a tag
  update      Updates a tag
```

```
❯ ./ans ecloud tag list
┌──────────────┬─────────────┬─────────────┬───────────────────────────┐
│      ID      │    SCOPE    │    NAME     │        CREATED AT         │
├──────────────┼─────────────┼─────────────┼───────────────────────────┤
│ tag-4e1da389 │ environment │ development │ 2025-08-05T16:39:57+00:00 │
│ tag-7cc863f3 │ environment │ production  │ 2025-08-05T09:09:34+00:00 │
└──────────────┴─────────────┴─────────────┴───────────────────────────┘
```