### PR TITLE
Default back to ASCII table formatting, make configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ is `table` or unspecified:
 
 The [Property Modifier](#property) is available for this format
 
+The table output style can be customised using the top-level `output_style` field in your configuration file. This directive accepts either `ascii` (default) or `unicode`, which will change the table output to use unicode characters for borders and lines.
+
 ### List
 
 Results can be output as a list using the `list` format:

--- a/README.md
+++ b/README.md
@@ -111,7 +111,13 @@ is `table` or unspecified:
 
 The [Property Modifier](#property) is available for this format
 
-The table output style can be customised using the top-level `output_style` field in your configuration file. This directive accepts either `ascii` (default) or `unicode`, which will change the table output to use unicode characters for borders and lines.
+The table output style can be customised using the `output.table.style` field in your configuration file. This directive accepts either `ascii` (default) or `unicode`, which will change the table output to use unicode characters for borders and lines.
+
+```yaml
+output:
+  table:
+    style: unicode
+```
 
 ### List
 

--- a/internal/pkg/output/output_handler.go
+++ b/internal/pkg/output/output_handler.go
@@ -11,8 +11,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ans-group/sdk-go/pkg/config"
 	"github.com/iancoleman/strcase"
 	"github.com/olekukonko/tablewriter"
+	"github.com/olekukonko/tablewriter/renderer"
 	"github.com/olekukonko/tablewriter/tw"
 	"github.com/ryanuber/go-glob"
 	"github.com/spf13/cobra"
@@ -110,9 +112,30 @@ func (o *OutputHandler) Table(cmd *cobra.Command, d interface{}) error {
 		return nil
 	}
 
+	// Get output style from configuration, default to "ascii"
+	var symbols tw.Symbols
+	outputStyle := config.GetString("output.table.style")
+	switch outputStyle {
+	case "unicode":
+		symbols = tw.NewSymbols(tw.StyleDefault)
+	default:
+		symbols = tw.NewSymbols(tw.StyleASCII)
+	}
+
 	table := tablewriter.NewTable(os.Stdout,
 		tablewriter.WithHeaderAlignment(tw.AlignCenter),
-		tablewriter.WithRowAlignment(tw.AlignLeft))
+		tablewriter.WithRowAlignment(tw.AlignLeft),
+		tablewriter.WithRenderer(renderer.NewBlueprint(tw.Rendition{Symbols: symbols})),
+		tablewriter.WithConfig(tablewriter.Config{
+			Row: tw.CellConfig{
+				Formatting:   tw.CellFormatting{AutoWrap: tw.WrapNormal},
+				ColMaxWidths: tw.CellWidth{Global: 30},
+			},
+			Header: tw.CellConfig{
+				Formatting:   tw.CellFormatting{AutoWrap: tw.WrapNormal},
+				ColMaxWidths: tw.CellWidth{Global: 30},
+			},
+		}))
 
 	table.Header(columns)
 	_ = table.Bulk(rows)


### PR DESCRIPTION
Change the default table output to use ASCII characters. Make switching to unicode option by setting `output_style: unicode` in the `.ans.yml` configuration file.

Adds wrapping options to table cells.