### PR TITLE
Allow application management through accounts

### DIFF
--- a/cmd/account/account.go
+++ b/cmd/account/account.go
@@ -16,6 +16,7 @@ func AccountRootCmd(f factory.ClientFactory) *cobra.Command {
 	cmd.AddCommand(accountContactRootCmd(f))
 	cmd.AddCommand(accountDetailsRootCmd(f))
 	cmd.AddCommand(accountCreditRootCmd(f))
+	cmd.AddCommand(accountApplicationRootCmd(f))
 
 	return cmd
 }

--- a/cmd/account/account_application.go
+++ b/cmd/account/account_application.go
@@ -1,0 +1,291 @@
+package account
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/ans-group/cli/internal/pkg/factory"
+	"github.com/ans-group/cli/internal/pkg/helper"
+	"github.com/ans-group/cli/internal/pkg/output"
+	"github.com/ans-group/sdk-go/pkg/service/account"
+	"github.com/spf13/cobra"
+)
+
+func accountApplicationRootCmd(f factory.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "application",
+		Short: "sub-commands relating to applications",
+	}
+
+	// Child commands
+	cmd.AddCommand(accountApplicationListCmd(f))
+	cmd.AddCommand(accountApplicationShowCmd(f))
+	cmd.AddCommand(accountApplicationCreateCmd(f))
+	cmd.AddCommand(accountApplicationUpdateCmd(f))
+	cmd.AddCommand(accountApplicationDeleteCmd(f))
+	cmd.AddCommand(accountApplicationRestrictionsRootCmd(f))
+
+	return cmd
+}
+
+func accountApplicationListCmd(f factory.ClientFactory) *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Short:   "Lists applications",
+		Long:    "This command lists applications",
+		Example: "ans account application list",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := f.NewClient()
+			if err != nil {
+				return err
+			}
+
+			return accountApplicationList(c.AccountService(), cmd, args)
+		},
+	}
+}
+
+func accountApplicationList(service account.AccountService, cmd *cobra.Command, args []string) error {
+	params, err := helper.GetAPIRequestParametersFromFlags(cmd)
+	if err != nil {
+		return err
+	}
+
+	applications, err := service.GetApplications(params)
+	if err != nil {
+		return fmt.Errorf("account: error retrieving applications: %s", err)
+	}
+
+	return output.CommandOutput(cmd, ApplicationCollection(applications))
+}
+
+func accountApplicationShowCmd(f factory.ClientFactory) *cobra.Command {
+	return &cobra.Command{
+		Use:     "show <application: id>...",
+		Short:   "Shows an application",
+		Long:    "This command shows one or more applications",
+		Example: "ans account application show 550e8400-e29b-41d4-a716-446655440000",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("missing application")
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := f.NewClient()
+			if err != nil {
+				return err
+			}
+
+			return accountApplicationShow(c.AccountService(), cmd, args)
+		},
+	}
+}
+
+func accountApplicationShow(service account.AccountService, cmd *cobra.Command, args []string) error {
+	var applications []account.Application
+	for _, arg := range args {
+		application, err := service.GetApplication(arg)
+		if err != nil {
+			output.OutputWithErrorLevelf("Error retrieving application [%s]: %s", arg, err)
+			continue
+		}
+
+		applications = append(applications, application)
+	}
+
+	return output.CommandOutput(cmd, ApplicationCollection(applications))
+}
+
+func accountApplicationCreateCmd(f factory.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "create",
+		Short:   "Creates an application",
+		Long:    "This command creates an application",
+		Example: "ans account application create --name \"My App\" --description \"My application description\"",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := f.NewClient()
+			if err != nil {
+				return err
+			}
+
+			return accountApplicationCreate(c.AccountService(), cmd, args)
+		},
+	}
+
+	// Setup flags
+	cmd.Flags().String("name", "", "Name of application")
+	cmd.MarkFlagRequired("name")
+	cmd.Flags().String("description", "", "Description of application")
+	cmd.Flags().StringSlice("allow-ip", []string{}, "IP addresses/ranges to allow (sets allowlist)")
+	cmd.Flags().StringSlice("deny-ip", []string{}, "IP addresses/ranges to deny (sets denylist)")
+
+	return cmd
+}
+
+func accountApplicationCreate(service account.AccountService, cmd *cobra.Command, args []string) error {
+	createRequest := account.CreateApplicationRequest{}
+	createRequest.Name, _ = cmd.Flags().GetString("name")
+	createRequest.Description, _ = cmd.Flags().GetString("description")
+
+	// Validate IP restriction flags are not both specified
+	allowIPs, _ := cmd.Flags().GetStringSlice("allow-ip")
+	denyIPs, _ := cmd.Flags().GetStringSlice("deny-ip")
+
+	if len(allowIPs) > 0 && len(denyIPs) > 0 {
+		return fmt.Errorf("account: cannot specify both --allow-ip and --deny-ip")
+	}
+
+	// Validate IP addresses/ranges
+	if err := validateIPRanges(allowIPs); err != nil {
+		return fmt.Errorf("account: invalid IP in --allow-ip: %s", err)
+	}
+	if err := validateIPRanges(denyIPs); err != nil {
+		return fmt.Errorf("account: invalid IP in --deny-ip: %s", err)
+	}
+
+	response, err := service.CreateApplication(createRequest)
+	if err != nil {
+		return fmt.Errorf("account: error creating application: %s", err)
+	}
+
+	// Set IP restrictions if specified
+	if len(allowIPs) > 0 || len(denyIPs) > 0 {
+		restrictionRequest := account.SetRestrictionRequest{}
+		if len(allowIPs) > 0 {
+			restrictionRequest.IPRestrictionType = "allowlist"
+			restrictionRequest.IPRanges = allowIPs
+		} else {
+			restrictionRequest.IPRestrictionType = "denylist"
+			restrictionRequest.IPRanges = denyIPs
+		}
+
+		err = service.SetApplicationRestrictions(response.ID, restrictionRequest)
+		if err != nil {
+			output.OutputWithErrorLevelf("Warning: Application created but failed to set IP restrictions: %s", err)
+		}
+	}
+
+	// Get the full application details to display
+	application, err := service.GetApplication(response.ID)
+	if err != nil {
+		return fmt.Errorf("account: error retrieving new application: %s", err)
+	}
+
+	return output.CommandOutput(cmd, ApplicationCollection([]account.Application{application}))
+}
+
+func accountApplicationUpdateCmd(f factory.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "update <application: id>...",
+		Short:   "Updates an application",
+		Long:    "This command updates one or more applications",
+		Example: "ans account application update 550e8400-e29b-41d4-a716-446655440000 --name \"Updated App\"",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("missing application")
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := f.NewClient()
+			if err != nil {
+				return err
+			}
+
+			return accountApplicationUpdate(c.AccountService(), cmd, args)
+		},
+	}
+
+	// Setup flags
+	cmd.Flags().String("name", "", "Name of application")
+	cmd.Flags().String("description", "", "Description of application")
+
+	return cmd
+}
+
+func accountApplicationUpdate(service account.AccountService, cmd *cobra.Command, args []string) error {
+	updateRequest := account.UpdateApplicationRequest{}
+	updateRequest.Name, _ = cmd.Flags().GetString("name")
+	updateRequest.Description, _ = cmd.Flags().GetString("description")
+
+	var applications []account.Application
+
+	for _, arg := range args {
+		err := service.UpdateApplication(arg, updateRequest)
+		if err != nil {
+			output.OutputWithErrorLevelf("Error updating application [%s]: %s", arg, err.Error())
+			continue
+		}
+
+		application, err := service.GetApplication(arg)
+		if err != nil {
+			output.OutputWithErrorLevelf("Error retrieving updated application [%s]: %s", arg, err.Error())
+			continue
+		}
+
+		applications = append(applications, application)
+	}
+
+	return output.CommandOutput(cmd, ApplicationCollection(applications))
+}
+
+func accountApplicationDeleteCmd(f factory.ClientFactory) *cobra.Command {
+	return &cobra.Command{
+		Use:     "delete <application: id>...",
+		Short:   "Removes an application",
+		Long:    "This command removes one or more applications",
+		Example: "ans account application delete 550e8400-e29b-41d4-a716-446655440000",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("missing application")
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := f.NewClient()
+			if err != nil {
+				return err
+			}
+
+			return accountApplicationDelete(c.AccountService(), cmd, args)
+		},
+	}
+}
+
+func accountApplicationDelete(service account.AccountService, cmd *cobra.Command, args []string) error {
+	var hasErrors bool
+	for _, arg := range args {
+		err := service.DeleteApplication(arg)
+		if err != nil {
+			output.OutputWithErrorLevelf("Error removing application [%s]: %s", arg, err)
+			hasErrors = true
+			continue
+		}
+	}
+
+	if hasErrors {
+		return fmt.Errorf("account: failed to delete one or more applications")
+	}
+	return nil
+}
+
+// validateIPRanges validates that all provided strings are valid IP addresses or CIDR ranges
+func validateIPRanges(ipRanges []string) error {
+	for _, ipRange := range ipRanges {
+		// Try parsing as CIDR first
+		_, _, err := net.ParseCIDR(ipRange)
+		if err != nil {
+			// If not CIDR, try parsing as IP
+			ip := net.ParseIP(ipRange)
+			if ip == nil {
+				return fmt.Errorf("invalid IP address or CIDR range: %s", ipRange)
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/account/account_application_restrictions.go
+++ b/cmd/account/account_application_restrictions.go
@@ -1,0 +1,207 @@
+package account
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ans-group/cli/internal/pkg/factory"
+	"github.com/ans-group/cli/internal/pkg/output"
+	"github.com/ans-group/sdk-go/pkg/service/account"
+	"github.com/spf13/cobra"
+)
+
+func accountApplicationRestrictionsRootCmd(f factory.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "restrictions",
+		Short: "sub-commands relating to application IP restrictions",
+	}
+
+	cmd.AddCommand(accountApplicationRestrictionsShowCmd(f))
+	cmd.AddCommand(accountApplicationRestrictionsSetCmd(f))
+	cmd.AddCommand(accountApplicationRestrictionsClearCmd(f))
+
+	return cmd
+}
+
+func accountApplicationRestrictionsShowCmd(f factory.ClientFactory) *cobra.Command {
+	return &cobra.Command{
+		Use:     "show <application: id>...",
+		Short:   "Shows application IP restrictions",
+		Long:    "This command shows IP restrictions for one or more applications",
+		Example: "ans account application restrictions show 550e8400-e29b-41d4-a716-446655440000",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("missing application")
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := f.NewClient()
+			if err != nil {
+				return err
+			}
+
+			return accountApplicationRestrictionsShow(c.AccountService(), cmd, args)
+		},
+	}
+}
+
+func accountApplicationRestrictionsShow(service account.AccountService, cmd *cobra.Command, args []string) error {
+	var restrictions []ApplicationRestrictionWithID
+	for _, arg := range args {
+		restriction, err := service.GetApplicationRestrictions(arg)
+		if err != nil {
+			output.OutputWithErrorLevelf("Error retrieving restrictions for application [%s]: %s", arg, err)
+			continue
+		}
+
+		// If IPRestrictionType is empty, no restrictions are set
+		restrictionType := restriction.IPRestrictionType
+		if restrictionType == "" {
+			restrictionType = "none"
+		}
+
+		restrictions = append(restrictions, ApplicationRestrictionWithID{
+			ID:                arg,
+			IPRestrictionType: restrictionType,
+			IPRanges:          restriction.IPRanges,
+		})
+	}
+
+	return output.CommandOutput(cmd, ApplicationRestrictionCollection(restrictions))
+}
+
+func accountApplicationRestrictionsSetCmd(f factory.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "set <application: id>",
+		Short:   "Sets IP restrictions for an application",
+		Long:    "This command sets IP restrictions for an application",
+		Example: "ans account application restrictions set 550e8400-e29b-41d4-a716-446655440000 --allow-ip \"198.51.100.0/24\"",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("missing application")
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := f.NewClient()
+			if err != nil {
+				return err
+			}
+
+			return accountApplicationRestrictionsSet(c.AccountService(), cmd, args)
+		},
+	}
+
+	// Setup flags
+	cmd.Flags().StringSlice("allow-ip", []string{}, "IP addresses/ranges to allow (sets allowlist)")
+	cmd.Flags().StringSlice("deny-ip", []string{}, "IP addresses/ranges to deny (sets denylist)")
+
+	return cmd
+}
+
+func accountApplicationRestrictionsSet(service account.AccountService, cmd *cobra.Command, args []string) error {
+	appID := args[0]
+
+	// Validate IP restriction flags
+	allowIPs, _ := cmd.Flags().GetStringSlice("allow-ip")
+	denyIPs, _ := cmd.Flags().GetStringSlice("deny-ip")
+
+	if len(allowIPs) == 0 && len(denyIPs) == 0 {
+		return fmt.Errorf("account: must specify either --allow-ip or --deny-ip")
+	}
+
+	if len(allowIPs) > 0 && len(denyIPs) > 0 {
+		return fmt.Errorf("account: cannot specify both --allow-ip and --deny-ip")
+	}
+
+	// Validate IP addresses/ranges
+	if err := validateIPRanges(allowIPs); err != nil {
+		return fmt.Errorf("account: invalid IP in --allow-ip: %s", err)
+	}
+	if err := validateIPRanges(denyIPs); err != nil {
+		return fmt.Errorf("account: invalid IP in --deny-ip: %s", err)
+	}
+
+	// Build restriction request
+	restrictionRequest := account.SetRestrictionRequest{}
+	if len(allowIPs) > 0 {
+		restrictionRequest.IPRestrictionType = "allowlist"
+		restrictionRequest.IPRanges = allowIPs
+	} else {
+		restrictionRequest.IPRestrictionType = "denylist"
+		restrictionRequest.IPRanges = denyIPs
+	}
+
+	err := service.SetApplicationRestrictions(appID, restrictionRequest)
+	if err != nil {
+		return fmt.Errorf("account: error setting application restrictions: %s", err)
+	}
+
+	// Get and display the updated restrictions
+	restriction, err := service.GetApplicationRestrictions(appID)
+	if err != nil {
+		// If we can't retrieve the updated restrictions, at least show what we tried to set
+		return output.CommandOutput(cmd, ApplicationRestrictionCollection([]ApplicationRestrictionWithID{{
+			ID:                appID,
+			IPRestrictionType: restrictionRequest.IPRestrictionType,
+			IPRanges:          restrictionRequest.IPRanges,
+		}}))
+	}
+
+	return output.CommandOutput(cmd, ApplicationRestrictionCollection([]ApplicationRestrictionWithID{{
+		ID:                appID,
+		IPRestrictionType: restriction.IPRestrictionType,
+		IPRanges:          restriction.IPRanges,
+	}}))
+}
+
+func accountApplicationRestrictionsClearCmd(f factory.ClientFactory) *cobra.Command {
+	return &cobra.Command{
+		Use:     "clear <application: id>...",
+		Short:   "Removes IP restrictions from applications",
+		Long:    "This command removes IP restrictions from one or more applications",
+		Example: "ans account application restrictions clear 550e8400-e29b-41d4-a716-446655440000",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("missing application")
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := f.NewClient()
+			if err != nil {
+				return err
+			}
+
+			return accountApplicationRestrictionsClear(c.AccountService(), cmd, args)
+		},
+	}
+}
+
+func accountApplicationRestrictionsClear(service account.AccountService, cmd *cobra.Command, args []string) error {
+	var hasErrors bool
+	for _, arg := range args {
+		err := service.DeleteApplicationRestrictions(arg)
+		if err != nil {
+			output.OutputWithErrorLevelf("Error clearing restrictions for application [%s]: %s", arg, err)
+			hasErrors = true
+			continue
+		}
+	}
+
+	if hasErrors {
+		return fmt.Errorf("account: failed to clear restrictions for one or more applications")
+	}
+	return nil
+}
+
+// ApplicationRestrictionWithID adds the application ID to the restriction for output
+type ApplicationRestrictionWithID struct {
+	ID                string   `json:"id"`
+	IPRestrictionType string   `json:"ip_restriction_type"`
+	IPRanges          []string `json:"ip_ranges"`
+}

--- a/cmd/account/account_application_test.go
+++ b/cmd/account/account_application_test.go
@@ -1,0 +1,129 @@
+package account
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ans-group/cli/test/mocks"
+	"github.com/ans-group/sdk-go/pkg/service/account"
+	gomock "github.com/golang/mock/gomock"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateIPRanges(t *testing.T) {
+	t.Run("ValidIPAddresses_ReturnsNil", func(t *testing.T) {
+		ipRanges := []string{"192.168.1.1", "10.0.0.1", "172.16.0.1"}
+		err := validateIPRanges(ipRanges)
+		assert.Nil(t, err)
+	})
+
+	t.Run("ValidCIDRRanges_ReturnsNil", func(t *testing.T) {
+		ipRanges := []string{"192.168.1.0/24", "10.0.0.0/8", "172.16.0.0/16"}
+		err := validateIPRanges(ipRanges)
+		assert.Nil(t, err)
+	})
+
+	t.Run("MixedValidIPsAndCIDR_ReturnsNil", func(t *testing.T) {
+		ipRanges := []string{"192.168.1.1", "10.0.0.0/8", "172.16.0.1"}
+		err := validateIPRanges(ipRanges)
+		assert.Nil(t, err)
+	})
+
+	t.Run("InvalidIPAddress_ReturnsError", func(t *testing.T) {
+		ipRanges := []string{"192.168.1.1", "invalid-ip", "172.16.0.1"}
+		err := validateIPRanges(ipRanges)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "invalid IP address or CIDR range: invalid-ip")
+	})
+
+	t.Run("InvalidCIDRRange_ReturnsError", func(t *testing.T) {
+		ipRanges := []string{"192.168.1.0/24", "10.0.0.0/99", "172.16.0.0/16"}
+		err := validateIPRanges(ipRanges)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "invalid IP address or CIDR range: 10.0.0.0/99")
+	})
+
+	t.Run("EmptySlice_ReturnsNil", func(t *testing.T) {
+		ipRanges := []string{}
+		err := validateIPRanges(ipRanges)
+		assert.Nil(t, err)
+	})
+}
+
+func Test_accountApplicationList(t *testing.T) {
+	t.Run("DefaultRetrieve", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockAccountService(mockCtrl)
+
+		service.EXPECT().GetApplications(gomock.Any()).Return([]account.Application{}, nil).Times(1)
+
+		accountApplicationList(service, &cobra.Command{}, []string{})
+	})
+
+	t.Run("GetApplicationsError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockAccountService(mockCtrl)
+
+		service.EXPECT().GetApplications(gomock.Any()).Return([]account.Application{}, errors.New("test error")).Times(1)
+
+		err := accountApplicationList(service, &cobra.Command{}, []string{})
+
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "test error")
+	})
+}
+
+func Test_accountApplicationShow(t *testing.T) {
+	t.Run("SingleApplication", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockAccountService(mockCtrl)
+
+		service.EXPECT().GetApplication("test-id").Return(account.Application{}, nil).Times(1)
+
+		accountApplicationShow(service, &cobra.Command{}, []string{"test-id"})
+	})
+
+	t.Run("MultipleApplications", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockAccountService(mockCtrl)
+
+		service.EXPECT().GetApplication("test-id1").Return(account.Application{}, nil).Times(1)
+		service.EXPECT().GetApplication("test-id2").Return(account.Application{}, nil).Times(1)
+
+		accountApplicationShow(service, &cobra.Command{}, []string{"test-id1", "test-id2"})
+	})
+}
+
+func Test_accountApplicationDelete(t *testing.T) {
+	t.Run("SingleApplication", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockAccountService(mockCtrl)
+
+		service.EXPECT().DeleteApplication("test-id").Return(nil).Times(1)
+
+		accountApplicationDelete(service, &cobra.Command{}, []string{"test-id"})
+	})
+
+	t.Run("MultipleApplications", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockAccountService(mockCtrl)
+
+		service.EXPECT().DeleteApplication("test-id1").Return(nil).Times(1)
+		service.EXPECT().DeleteApplication("test-id2").Return(nil).Times(1)
+
+		accountApplicationDelete(service, &cobra.Command{}, []string{"test-id1", "test-id2"})
+	})
+}

--- a/cmd/account/output.go
+++ b/cmd/account/output.go
@@ -1,6 +1,9 @@
 package account
 
 import (
+	"strings"
+
+	"github.com/ans-group/cli/internal/pkg/output"
 	"github.com/ans-group/sdk-go/pkg/service/account"
 )
 
@@ -26,4 +29,42 @@ type ClientCollection []account.Client
 
 func (m ClientCollection) DefaultColumns() []string {
 	return []string{"id", "company_name"}
+}
+
+type ApplicationCollection []account.Application
+
+func (m ApplicationCollection) DefaultColumns() []string {
+	return []string{"id", "name", "description", "created_at", "created_by"}
+}
+
+func (m ApplicationCollection) Fields() []*output.OrderedFields {
+	var data []*output.OrderedFields
+	for _, app := range m {
+		fields := output.NewOrderedFields()
+		fields.Set("id", app.ID)
+		fields.Set("name", app.Name)
+		fields.Set("description", app.Description)
+		fields.Set("created_at", app.CreatedAt.String())
+		fields.Set("created_by", app.CreatedBy)
+		data = append(data, fields)
+	}
+	return data
+}
+
+type ApplicationRestrictionCollection []ApplicationRestrictionWithID
+
+func (m ApplicationRestrictionCollection) DefaultColumns() []string {
+	return []string{"id", "ip_restriction_type", "ip_ranges"}
+}
+
+func (m ApplicationRestrictionCollection) Fields() []*output.OrderedFields {
+	var data []*output.OrderedFields
+	for _, restriction := range m {
+		fields := output.NewOrderedFields()
+		fields.Set("id", restriction.ID)
+		fields.Set("ip_restriction_type", restriction.IPRestrictionType)
+		fields.Set("ip_ranges", strings.Join(restriction.IPRanges, ", "))
+		data = append(data, fields)
+	}
+	return data
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.5
 
 require (
-	github.com/ans-group/sdk-go v1.25.1
+	github.com/ans-group/sdk-go v1.25.2
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/golang/mock v1.6.0
 	github.com/iancoleman/strcase v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/ans-group/go-durationstring v1.2.0 h1:UJIuQATkp0t1rBvZsHRwki33YHV9E+Ulro+3NbMB7MM=
 github.com/ans-group/go-durationstring v1.2.0/go.mod h1:QGF9Mdpq9058QXaut8r55QWu6lcHX6i/GvF1PZVkV6o=
-github.com/ans-group/sdk-go v1.25.1 h1:/SdnjofRu8Tg/yNjTh61DYINfRxoYJqv17cV9N0lJDg=
-github.com/ans-group/sdk-go v1.25.1/go.mod h1:Dx34ZUbyHNniHAKsDy/vp8q8hQC5L51ub2sv9We7d8E=
+github.com/ans-group/sdk-go v1.25.2 h1:hvowUT3GaiO+JTM5kjzX9oAu+ZgyGdnAlT2XtrVgPGA=
+github.com/ans-group/sdk-go v1.25.2/go.mod h1:Dx34ZUbyHNniHAKsDy/vp8q8hQC5L51ub2sv9We7d8E=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=


### PR DESCRIPTION
```
❯ ./ans account application --help
sub-commands relating to applications

Usage:
  ans account application [command]

Available Commands:
  create       Creates an application
  delete       Removes an application
  list         Lists applications
  restrictions sub-commands relating to application IP restrictions
  show         Shows an application
  update       Updates an application

...snip...
```
 
```
❯ ./ans account application create --help
This command creates an application

Usage:
  ans account application create [flags]

Examples:
ans account application create --name "My App" --description "My application description"

Flags:
      --allow-ip strings     IP addresses/ranges to allow (sets allowlist)
      --deny-ip strings      IP addresses/ranges to deny (sets denylist)
      --description string   Description of application
  -h, --help                 help for create
      --name string          Name of application

...snip...
```

```
sub-commands relating to application IP restrictions

Usage:
  ans account application restrictions [command]

Available Commands:
  clear       Removes IP restrictions from applications
  set         Sets IP restrictions for an application
  show        Shows application IP restrictions

Flags:
  -h, --help   help for restrictions

...snip...
```

